### PR TITLE
Pipeline parity: modularize join script, add DQ checks, project plan

### DIFF
--- a/.compound-engineering/config.local.example.yaml
+++ b/.compound-engineering/config.local.example.yaml
@@ -1,0 +1,48 @@
+# Compound Engineering -- local config
+# Copy to .compound-engineering/config.local.yaml in your project root.
+# All settings are optional. Invalid values fall through to defaults.
+
+# --- Work delegation (Codex) ---
+
+# work_delegate: codex           # codex | false (default: false)
+# work_delegate_consent: true    # true | false (default: false)
+# work_delegate_sandbox: yolo    # yolo | full-auto (default: yolo)
+# work_delegate_decision: auto   # auto | ask (default: auto)
+# work_delegate_model: gpt-5.4   # any valid codex model (omit to use ~/.codex/config.toml default)
+# work_delegate_effort: high     # minimal | low | medium | high | xhigh (omit to use ~/.codex/config.toml default)
+
+# --- Product pulse ---
+# Settings written by /ce-product-pulse first-run interview. Re-run the skill with
+# argument `setup` or `reconfigure` to edit interactively.
+
+# pulse_product_name: "Spiral"                          # used in report titles (no default)
+# pulse_lookback_default: 24h                           # 1h | 24h | 7d | 30d (default: 24h)
+# pulse_primary_event: "session_started"                # the event that means "user showed up"
+# pulse_value_event: "task_completed"                   # the event that means "user got value"
+# pulse_completion_events: "onboarded,first_purchase"   # comma-separated, 0-3 events
+# pulse_quality_scoring: false                          # true | false (default: false; AI products only)
+# pulse_quality_dimension: "answer accuracy"            # dimension scored 1-5 when pulse_quality_scoring is true
+# pulse_analytics_source: posthog                       # posthog | mixpanel | custom (no default)
+# pulse_tracing_source: sentry                          # sentry | datadog | custom (no default)
+# pulse_payments_source: stripe                         # stripe | custom (no default)
+# pulse_db_enabled: false                               # true | false (default: false; read-only DB if true)
+# pulse_metric_sources: "retention_d7=posthog,nps=delighted"  # strategy-metric -> source overrides; comma-separated 'metric=source' pairs; unlisted metrics fall back to pulse_analytics_source
+# pulse_pending_metrics: "retention_d7,nps"             # comma-separated strategy metrics awaiting instrumentation; render as 'no data'
+# pulse_excluded_metrics: "north_star"                  # comma-separated strategy metrics intentionally not in pulse
+
+# --- Output format ---
+# Per-skill output format default. Selects the exclusive format the artifact
+# is written in: `md` produces a markdown file, `html` produces a single
+# self-contained HTML file. The two are mutually exclusive -- there is no
+# sibling artifact. See DESIGN.md or your agent instructions to influence
+# HTML styling. CLI arguments override these defaults; pipeline contexts
+# (e.g., LFG, disable-model-invocation) always force `md` regardless.
+
+# plan_output: html              # md | html (default: md)
+# brainstorm_output: html        # md | html (default: md)
+
+# --- ce-promote ---
+# Written automatically when you decline the Spiral setup offer in /ce-promote.
+# Suppresses that one-time setup nudge in this project. Remove the key to re-enable.
+
+# ce_promote_spiral_optout: true   # true | (absent) (default: absent -- offer once)

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ data/
 # macOS
 .DS_Store
 
+# Editor / local tool config
+.vscode/
+.compound-engineering/config.local.yaml
+
 ### Python ###
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,4 @@ poetry.toml
 
 # LSP config files
 pyrightconfig.json
+.compound-engineering/*.local.yaml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,73 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+A data pipeline and dashboard for NYC schools showing Green Healthy Schools (GHS) prioritization under Zohran's climate plan. Identifies schools for renovation and optimal areas for canvassing based on proximity to priority schools and political support data.
+
+**Current state:** The live dashboard runs on ArcGIS Dashboards (not in this repo). This repo is the data processing layer — notebooks process raw source data and produce `master_schools.geojson`, which feeds ArcGIS. There is meaningful drift between what's in ArcGIS (which has received manual hotfixes from a colleague) and what the notebooks currently produce; backporting those changes is ongoing work.
+
+**North star:** Replace notebooks with a pure Python pipeline (`pipelines/` folder, one `.py` file per data layer) that runs on a schedule or event trigger, and replace ArcGIS Dashboards with a custom JS-based map dashboard. The current ArcGIS workflow has a major ergonomic problem: ArcGIS Online doesn't support bulk replacement of `master_schools.geojson`, so every new column must be uploaded individually.
+
+**`apps/` and `src/`** are dead code from earlier attempts at a Python-based dashboard (tried Streamlit+PyDeck, Dash-Leaflet, and Folium — all proved too slow/limited). Do not suggest Python-based dashboard solutions. Keep these directories for now pending planning.
+
+## Commands
+
+This project uses [`just`](https://github.com/casey/just) as a task runner and `uv` for package management.
+
+```bash
+just setup       # Full setup: install system deps, create venv, install package, setup pre-commit
+just lint        # Run Ruff linter
+just format      # Format code with Ruff
+just test        # Run pytest
+just sync        # Sync venv with pyproject.toml deps
+just hooks-all   # Run pre-commit hooks on all files
+just clean-env   # Rebuild virtual environment from scratch
+```
+
+macOS system dependencies required: `brew install proj ghostscript`
+
+## Data Pipeline Architecture
+
+### Flow
+
+Raw data (`data/raw_data/`) → processing notebooks → `data/processed_data/` → `join_to_schools.ipynb` → `master_schools.geojson` → (manually uploaded to) ArcGIS Dashboards
+
+### Processing notebooks (each independent, all feed into the join)
+
+- `process_dacs.ipynb` — NYSERDA Disadvantaged Communities → `dac_nyc_*.geojson`
+- `process_school_locations.ipynb` — DOE LCGMS + Google Maps geocoding → `school_points_with_lcgms.*`
+- `process_cast_vote_record.ipynb` — 2025 mayoral primary results → `zohran_first_round_frac.geojson`
+- `process_solar_readiness.ipynb` — DCAS LL24 data → `solar_readiness_assessment_doe_buildings_*.parquet`
+- `process_ll84.ipynb` — NYC LL84 energy efficiency → `ll84.geojson`
+- `process_bap.ipynb` — Building Accessibility Profile
+- `process_ghs_survey_data.ipynb` — GHS survey responses
+- `process_ventilation.ipynb` — HVAC/ventilation data
+- `schools_lead_paint.ipynb` — lead paint hazards
+- `capacity_utilization.ipynb` — SCA building capacity & utilization
+- `city_council_districts.ipynb` — City Council district boundaries
+
+**Master join**: `notebooks/join_to_schools.ipynb` — spatial-joins all processed layers onto school points (nearest-neighbor fallback for election results) → `data/processed_data/master_schools.geojson`
+
+`notebooks/andre_working/` — additional layers in development (air pollution, subway distance, hurricane evacuation, cooling centers, stormwater) that are not yet integrated into the join.
+
+### Data directory
+
+- `data/raw_data/` — immutable source files organized by agency (DCAS, DOB, DOE, SCA, NYSERDA, etc.)
+- `data/processed_data/` — cleaned outputs; `master_schools.geojson` is the primary schools layer
+- Processed data formats: GeoJSON for vector layers, Parquet for tabular data (preserves dtypes)
+
+### Environment
+
+Requires `.env` with `GOOGLE_MAPS_API_KEY` for the geocoding notebook. `data/processed_data/google_maps_geocode_cache.json` caches prior geocoding results.
+
+## Conventions
+
+- Package manager: `uv` (not pip/conda)
+- Linter/formatter: Ruff (line length 88), enforced via pre-commit
+- **Notebooks are committed clean — no cell outputs.** This is intentional so that data quality can be checked during development without committing large outputs.
+- Schools to buildings is a many-to-one relationship — multiple schools can share a building. Most data in this project is at the building level, so joins should typically use building code rather than `LocationCode`. Both identifiers are important and both appear throughout the data. The building code is called `Building Code` in the LCGMS data but appears under various field names in other datasets — check carefully when joining.
+- When the current state of the ArcGIS dashboard is relevant to a task, ask the user for a screenshot rather than assuming the notebooks reflect the live dashboard state.
+- When adding new layers to `join_to_schools.ipynb`, include DQ checks to verify that existing columns haven't shifted.
+- Commit messages are a single line, no body. Further explanation belongs in the PR description, not the commit message.

--- a/docs/Andre Processing Notes.md
+++ b/docs/Andre Processing Notes.md
@@ -1,0 +1,134 @@
+**Processing notes for aligning workflow**
+
+- ***All code has been added to** [andre\_working](https://github.com/likealostcause/zohran-ghs-dashboard/tree/main/notebooks/andre_working) **folder in the notebooks directory of the github.***
+- ***The following section is not in any particular order.***
+
+1. Alignment of school points that belong to the same building.
+   1. I noticed that some school points that belong to the same building were not in the same location, giving the appearance of multiple buildings. To fix this I did:
+      1. Code: Ran [*snap\_points\_by\_BuildingCode.py*](https://github.com/likealostcause/zohran-ghs-dashboard/blob/main/notebooks/andre_working/snap_points_by_BuildingCode.py)
+         1. Code uses *Bldg\_Code* field to align all points that share the same code and update their lat & long fields.
+
+	\* Priority. Future master\_schools should have this updated geometry before I update
+
+2. School Districts
+   1. Downloaded School Districts (Clipped to Shoreline) from [NYC OpenData](https://www.nyc.gov/content/planning/pages/resources/datasets/school-districts) (nysd\_25d)
+      1. Reprojected *nysd* layer to 4326 and saved as a geojson for adding to dashboard
+      2. Ran *Fix geometries*  (repair method: structure) on school district layer
+      3. Ran a Join By Location to add the *SchoolDist* attribute to master schools
+      4. Uploaded layer to [drive](https://drive.google.com/file/d/1eUMwS8chRQwdB8VCjPXysNXzVQR5NNJG/view?usp=drive_link), and added as a layer in the dashboard map called school\_districts.geojson
+
+	\* I realized when doing this that there’s a more updated version of school districts, so I redid this. Also I realize this may actually already be what you did for school districts, so you might not need to update this.
+
+3. State Assembly Districts
+   1. Downloaded State Assembly Districts (Clipped to Shoreline) from [NYC OpenData](https://www.nyc.gov/content/planning/pages/resources/datasets/state-assembly) (nyad\_25d)
+      1. Reprojected *nyad* layer to 4326 and saved as a geojson for adding to dashboard
+      2. Ran *Fix geometries*  (repair method: structure) on nyad layer
+      3. Ran a Join By Location to add the *AssemDist* attribute to master schools
+      4. Uploaded layer to [drive](https://drive.google.com/file/d/1ODub1-6BuXA5KclBsC6WnvE57cFvMYkr/view?usp=drive_link), and added as a layer in the dashboard map called ny\_assembly\_district.geojson
+
+4. State Senate Districts
+   1. Downloaded State Assembly Districts (Clipped to Shoreline) from [NYC OpenData](https://www.nyc.gov/content/planning/pages/resources/datasets/state-senate) (nyss\_25d)
+      1. Reprojected *nyss* layer to 4326 and saved as a geojson for adding to dashboard
+      2. Ran *Fix geometries*  (repair method: structure) on nyss layer
+      3. Ran a Join By Location to add the *StSenDist* attribute to master schools
+      4. Uploaded layer to [drive](https://drive.google.com/file/d/1ODub1-6BuXA5KclBsC6WnvE57cFvMYkr/view?usp=drive_link), and added as a layer in the dashboard map called NY\_State\_Senate\_Districts.geojson
+
+5. Distance from peaker plants
+   1. Downloaded all peaker plants from this tool: [https://www.cleanegroup.org/initiatives/phase-out-peakers/maps/](https://www.cleanegroup.org/initiatives/phase-out-peakers/maps/)
+   2. Clipped peaker plants to plants 5 miles from NYC schools
+      1. Buffer school layer by 5 miles
+      2. Use buffer to Clip peaker plants
+   3. Calculate the distance in miles from school points to the nearest peaker plant and add that as a field to the master schools layer
+      1. See [EvacCenters distance code](https://github.com/likealostcause/zohran-ghs-dashboard/blob/main/notebooks/andre_working/hurricaneEvac_HeatIndex_distEvacCenters_distCoolingCenters.py)
+
+6. On an open street
+   1. Abhi actually did this one, check in with him
+   2. According to the guide the datasource is this: [https://data.cityofnewyork.us/Health/Open-Streets-Locations/uiay-nctu/about\_data](https://data.cityofnewyork.us/Health/Open-Streets-Locations/uiay-nctu/about_data)
+   3. I believe he did a buffer of 300 ft around open street locations and did an intersect with that.
+   4. Resulting field is boolean, yes or no on an open street.
+
+7. walking distance from subway
+   1. First the layer was found on [ArcGIS online](https://ecosocialists.maps.arcgis.com/home/item.html?id=abfdf749f2104b8c952bd59bf004b8b6) (need account). *\[this is step does not need to be added to your work flow, i just included for reference\]*
+   2. From the ArcGIS online page we find the Feature server link: [https://services1.arcgis.com/HmwnYiJTBZ4UkySc/arcgis/rest/services/Walking\_Distance/FeatureServer](https://services1.arcgis.com/HmwnYiJTBZ4UkySc/arcgis/rest/services/Walking_Distance/FeatureServer)
+   3. The feature service link can be used to get the json of the layer and make a geojson from that.
+      1. This [script](https://github.com/likealostcause/zohran-ghs-dashboard/blob/main/notebooks/andre_working/download_geojson_from_arc_server.py) will create the geojson from the feature server URL
+   4. Once I have the walking distance geojson:
+      1. I used this [script](https://github.com/likealostcause/zohran-ghs-dashboard/blob/main/notebooks/andre_working/dist_to_subway_processing.py) to get the *subway\_dist* field on the school layer
+         1. Spatially joined polygons to points to bring over the *WalkingB\_1* field.
+         2. Created a new text field *subway\_dist* on the schools layer.
+         3. Cleaned/standardized the joined values: removed spaces around the dash, added " min", and set null joins to "\>10 min".
+
+8. hurricane evacuation zone, heat exposure index, distance from evac center, distance from cooling center
+   1. The steps for these 4 fields has been consolidated in this [script](https://github.com/likealostcause/zohran-ghs-dashboard/blob/main/notebooks/andre_working/hurricaneEvac_HeatIndex_distEvacCenters_distCoolingCenters.py)
+   2. Field name : Data source:
+      1. hurricane\_evacZone : [Hurricane Evac Zones](https://data.cityofnewyork.us/City-Government/Hurricane-Evacuation-Zones/epne-qv9x/about_data)
+      2. OHEI : [Outdoor Heat Exposure Index](https://urbanheat.nyc/#/download)
+      3. evacCenters\_distance\_mi : [Distance from Evac centers](https://data.cityofnewyork.us/Public-Safety/Hurricane-Evacuation-Centers/p5md-weyf/about_data)
+      4. Cooling\_centers\_distance\_mi : [Distance from Cooling Centers](https://www.arcgis.com/home/item.html?id=a0643f21b5e24d1ea3ba1406775c4e52)
+         1. To download as a geojson, use the feature service url in this [script](https://github.com/likealostcause/zohran-ghs-dashboard/blob/main/notebooks/andre_working/download_geojson_from_arc_server.py)
+            1. https://services6.arcgis.com/yG5s3afENB5iO9fj/arcgis/rest/services/CoolingCenters\_PROD\_view/FeatureServer
+   3. Steps:
+      1. Evac Zones and OHEI were a simple join attribute by location
+      2. The distance fields were a distance in mile from each school to the nearest evac center/cooling center
+
+9. avg pm2.5 & avg no2
+   1. Download the NYCCAS Air Pollution Rasters [here](https://data.cityofnewyork.us/Environment/NYCCAS-Air-Pollution-Rasters/q68s-8qxv/about_data)
+   2. Run this [script](https://github.com/likealostcause/zohran-ghs-dashboard/blob/main/notebooks/andre_working/process_air_pollution_and_join.py) for processing the rasters and extracting the fields.
+      1. Direct the script to the unzipped AnnAvg\_1\_15\_300m folder. It will find the required rasters:
+         1.    aa14\_pm300m (PM2.5)
+         2.    aa14\_no2300m (NO2)
+      2. The script then samples the rasters with the school points and creates these fields:
+         1. pm25\_2022
+         2. No2\_2022
+
+   \* Note that these field outputs are continuous, they will be converted into percentile in a diff step.
+
+10. stormwater flood risks (3 fields)
+    1. The data was downloaded [here](https://data.cityofnewyork.us/Environment/NYC-Stormwater-Flood-Maps/9i7c-xyvv/about_data)
+       1. The downloaded zip file has issues opening since the file names are too long to unzip.
+          1. Might be easier to just use the preprocessed layer in the [drive](https://drive.google.com/file/d/1jW7XCrHZTDRmH9V3aRIhn0HgzfR1FYL6/view?usp=drive_link) and skip steps *a* to *f*
+    2. We only used the current sea level layers:
+       1. NYC Stormwater Flood Map \- Limited Flood (1.77 inches per hr) with Current Sea Levels
+       2. NYC Stormwater Flood Map \- Moderate Flood (2.13 inches per hr) with Current Sea Levels
+    3. Create a field called *Flood\_Scenario* and populate it based on the file name and this [table](https://experience.arcgis.com/experience/e83a49daef8a472da4a7e34dc25ac445/).  See table below for the created field values
+    4. Create a field called *Flood\_Category* populate it using the *Flooding\_C* field,
+    5. Once downloaded I merged the two current sea level layers using Union. See table below for the created field values.
+    6. Then I did a dissolve by the *Flood\_Scenario* and *Flood\_Category* fields
+       1. Make sure that fields from the union are combined
+       2. You should end up with four entries
+       3. I created an integer field called *Stormwater\_Flood\_Risk* and then manually added values according to the table below. 1 being the greatest risk of the most likely occurence:
+
+| Flood\_Scenario | Flood\_Category | Stormwater\_Flood\_Risk |
+| :---- | :---- | :---- |
+| Limited Flood: 1.77in/hr with current sea level (20% chance of yearly occurence) | Deep and Contiguous Flooding (1 ft. and greater) | 1 |
+| Limited Flood: 1.77in/hr with current sea level (20% chance of yearly occurence) | Nuisance Flooding (greater or equal to 4 in. and less than 1 ft.) | 2 |
+| Moderate Flood: 2.13in/hr with current sea level (10% chance of yearly occurence) | Deep and Contiguous Flooding (1 ft. and greater) | 3 |
+| Moderate Flood: 2.13in/hr with current sea level (10% chance of yearly occurence) | Nuisance Flooding (greater or equal to 4 in. and less than 1 ft.) | 4 |
+
+       4. After creating these fields, I used this [script](https://github.com/likealostcause/zohran-ghs-dashboard/blob/main/notebooks/andre_working/storm_water_ranked_join.py) to do a ranked join with the school points layer
+          1. School points are buffered by 300 feet and then they join the attribute of the polygon that they overlap with the highest rank (1 being the highest rank)
+             1. So if a school buffer overlaps risks 3 and 4, it gets the attribute of risk 3
+
+11. Converting continuous fields to percentile fields
+    1. The following fields were converted into quartiles in order to make categorical filters:
+       1.    "no2\_2022",
+       2.     "pm25\_2022",
+       3.     "ENERGY\_STAR\_Score",
+       4.     "Direct\_GHG\_Emissions\_\_Metric\_Tons\_CO2e\_",
+       5.     "Site\_EUI\_\_kBtu\_ft²\_",
+       6.     "Percent\_Electricity",
+       7.     "Electricity\_Use\_–\_Generated\_from\_Onsite\_Renewable\_Systems\_\_kWh\_",
+       8.     "Fuel\_Oil\_\_2\_Use\_\_kBtu\_",
+       9.     "Fuel\_Oil\_\_4\_Use\_\_kBtu\_",
+       10.     "District\_Steam\_Use\_\_kBtu\_",
+       11.     "District\_Hot\_Water\_Use\_\_kBtu\_",
+       12.     "Natural\_Gas\_Use\_\_kBtu\_",
+       13.     "Diesel\_\_2\_Use\_\_kBtu\_"
+    2. This was done using this [script](https://github.com/likealostcause/zohran-ghs-dashboard/blob/main/notebooks/andre_working/convert_continous_to_percentile_class.py)
+       1. The script replaces every *NULL* value with the string “No data”
+
+A
+
+\_pct
+
+*\* Note that this doesn’t yet make the A/C fields into percentiles, I have not gotten to that.*

--- a/docs/brainstorms/2026-06-06-pipeline-parity-and-automation-requirements.md
+++ b/docs/brainstorms/2026-06-06-pipeline-parity-and-automation-requirements.md
@@ -1,0 +1,123 @@
+---
+date: 2026-06-06
+topic: pipeline-parity-and-automation
+---
+
+## Summary
+
+Get the GHS dashboard pipeline to a state where monthly data refreshes are practical and low-friction. Four phases: achieve parity between the repo and the live ArcGIS dashboard (field names and data layers), add DQ checks that make updates trustworthy, validate the upload workflow with already-processed layers, then automate the end-to-end pipeline so a refresh requires a single command.
+
+---
+
+## Problem Frame
+
+The repo and the live ArcGIS dashboard have drifted. André's processing added roughly a dozen new fields directly in ArcGIS that are not in the notebooks or pipeline script, and field names between the repo's output and the ArcGIS feature service don't match. Local analysis work and the live dashboard are not directly comparable, which makes every proposed update feel risky.
+
+The ArcGIS upload process compounds this: adding new columns requires column-by-column manual uploads. The result is a backlog of fully-processed data that hasn't been uploaded (lead paint, GHS survey) and reluctance to start new work because shipping it is painful.
+
+---
+
+## Key Decisions
+
+**Parity before new features.** Field name mismatches and missing André layers make local analysis untrustworthy. Parity must come first even though it delivers no new campaign-facing value.
+
+**ArcGIS stays as the deployment target.** The dashboard's filtering capabilities have no comparable alternative given current JS skills and bandwidth. Upload automation — not dashboard replacement — is the lever to reduce friction.
+
+**`pipelines/join_to_schools.py` is the canonical join.** No new join work goes into `notebooks/join_to_schools.ipynb`. The notebook stays for reference; the pipeline script is where all future development happens.
+
+**GHS survey branch closes before parity work begins.** The branch is 90% done. Closing it removes one open thread and produces a layer ready for the upload validation phase.
+
+---
+
+## Requirements
+
+**Parity**
+
+R1. All layers from `docs/Andre Processing Notes.md` are implemented in `pipelines/join_to_schools.py`: snap points by building code (geometry fix), school districts (verify if already present), assembly districts, state senate districts, subway walking distance, peaker plant distance, hurricane evac zone / heat exposure index / evac center distance / cooling center distance, air pollution (PM2.5 and NO2), stormwater flood risk, open street flag, and percentile/quartile conversions for LL84 energy fields and air pollution fields.
+
+R2. Column names in the pipeline's output match the field names in the live ArcGIS feature service. A field list export from ArcGIS establishes the target schema; mismatches surface as errors, not silent renames.
+
+R3. The snap-points-by-building-code geometry fix is applied to school points before any spatial joins run.
+
+**DQ checks**
+
+R4. After each join in `pipelines/join_to_schools.py`, assertions verify: row count is unchanged, null counts on key existing columns haven't increased, and no duplicate `LocationCode` values are present.
+
+R5. Join match rate is logged for each layer; a match rate below an expected threshold triggers an error and halts export.
+
+R6. Before export, a final assertion compares the output field list against a pinned expected schema, catching unintended column additions or drops.
+
+**GHS survey completion**
+
+R7. `notebooks/process_ghs_survey_data.ipynb` is finalized. The only field added to the join is a count of respondents per school who expressed willingness to get involved; no raw or identifying survey data is included.
+
+R8. The GHS survey field is added to `pipelines/join_to_schools.py` and the `process-ghs-survey-data` branch is merged and closed.
+
+**Upload validation**
+
+R9. Lead paint data (`notebooks/schools_lead_paint.ipynb` — already processed) is added to the join and uploaded to ArcGIS, validating the upload workflow end-to-end before further new layers are added.
+
+R10. GHS survey data (from R7–R8) is uploaded to ArcGIS as a second upload validation exercise.
+
+**Pipeline automation**
+
+R11. A single command (e.g., `just update`) runs all individual processing scripts in sequence and produces an updated `data/processed_data/master_schools.geojson`.
+
+R12. The `just update` command includes the DQ checks from R4–R6 and aborts with a clear error message if any check fails.
+
+**Upload automation**
+
+R13. A scripted column-by-column upload reduces the manual ArcGIS update process to a single command. Full-service overwrite is not a viable approach: the ArcGIS setup has three layers (hosted feature service → web map → dashboard), and replacing the feature service in place breaks all dashboard widget and filter field mappings. New columns must be added to the existing service to preserve those mappings.
+
+R14. New columns are first tested against a duplicate (staging) dashboard before being applied to the live public-facing dashboard.
+
+---
+
+## Scope Boundaries
+
+**Deferred for later**
+- Net-new data layers (green schoolyard, lead pipes, asbestos, etc.) — start after pipeline automation is in place and the upload workflow is validated with lead paint and GHS survey
+- Ventilation/A/C web scraping — requires getting the existing scraping code into the repo first (separate workstream)
+- Simplifying school locations processing (LCGMS-only + Google Maps geocode) — deferred until before the next LCGMS data drop, expected later in 2026
+
+**Out of scope**
+- ArcGIS dashboard replacement — filtering requirements have no comparable open-source alternative; remains a long-term aspiration only
+
+---
+
+## Dependencies / Assumptions
+
+- A field list export from the live ArcGIS feature service is required before column name reconciliation (R2) can be scoped. Without it, the mismatch is not estimable.
+- André's working scripts in `notebooks/andre_working/` are the reference implementation for the parity layers in R1.
+- The `arcgis` Python package can add new columns to an existing hosted feature service without a full overwrite (assumed; if false, upload automation takes a different scripted approach).
+
+---
+
+## Outstanding Questions
+
+**Resolve before planning**
+
+*(None remaining)*
+
+**Deferred to planning**
+
+- Does the snap-points-by-building-code geometry fix need to be applied once and saved back to `data/processed_data/school_points_with_lcgms.*`, or re-run at the start of each pipeline execution? (Determine from André's `notebooks/andre_working/snap_points_by_BuildingCode.py`.)
+- Full column name reconciliation: compare `pipelines/join_to_schools.py` output schema against the 179-field ArcGIS schema to identify all mismatches (not just the confirmed `ZohranFirstRoundFrac` → `ZohrPrimR1` one).
+- IBO School Barriers fields: determine whether they were ever uploaded to ArcGIS, need to be uploaded, or should be dropped from the pipeline.
+- What is the remaining 10% of work on the GHS survey notebook?
+- What is `docs/join_to_schools.py`? Is it André's version, an older copy, or something else? Should it be moved to `pipelines/` or deleted?
+- What join match rate thresholds (R5) are acceptable for each layer? Some layers like subway distance will have near-100% coverage; others may legitimately have gaps.
+
+---
+
+## Sources
+
+- André's processing notes and reference scripts: `docs/Andre Processing Notes.md`, `notebooks/andre_working/`
+- Existing pipeline script (covers boroughs, DACs, election results, A/C, ventilation, capacity/utilization, BAP, IBO barriers, solar readiness, city council + school districts, LL84): `pipelines/join_to_schools.py`
+- Project plan and phased overview: `docs/plan.md`
+- Live ArcGIS feature service (179 fields, queryable via REST): `https://services7.arcgis.com/2QFP7OYxiYK7rWSP/arcgis/rest/services/master_schools_v2/FeatureServer/0?f=json`
+- ArcGIS dashboard item: `https://ecosocialists.maps.arcgis.com/home/item.html?id=b16342d504e04a9a9320637906fed6f1`
+- Confirmed field name mismatch (at minimum): `ZohranFirstRoundFrac` (pipeline) → `ZohrPrimR1` (ArcGIS). A full comparison of pipeline output columns against the 179-field ArcGIS schema is needed during planning.
+- André's layers are confirmed present in ArcGIS (`hurricane_evacZone`, `OHEI`, `evacCenters_distance_mi`, `cooling_centers_distance_mi`, `subway_dist`, `on_open_street`, `NY_State_Senate_District`, `NY_State_Assembly_District`, `pm25_2022`, `no2_2022`, `Flood_Scenario`, `Stormwater_Flood_Risk`, `peaker_mi`, percentile fields). Parity work adds these to the pipeline script so local output matches what is live.
+- IBO School Barriers fields appear in `pipelines/join_to_schools.py` but are not in the ArcGIS field list — status unknown (never uploaded, or dropped).
+- Lead paint and GHS survey fields are not in ArcGIS — confirmed upload backlog items for R9–R10.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,0 +1,118 @@
+# Project Plan
+
+## Current State
+
+The live dashboard runs on ArcGIS Dashboards and is actively used by the campaign. This repo is the data processing layer: Jupyter notebooks process raw source data and produce `master_schools.geojson`, which is manually uploaded to ArcGIS Online.
+
+There are two sources of drift between this repo and the live dashboard:
+1. **André's processing** — a set of new data layers and geometry fixes applied directly in ArcGIS that are not yet reflected in the notebooks (documented in `docs/Andre Processing Notes.md`)
+2. **Hotfixes** — manual edits made directly in ArcGIS Online by André and others that need to be backported into the processing code
+
+The primary risk this creates: if data in ArcGIS were accidentally deleted or corrupted, we could not quickly reproduce it from this repo.
+
+Data sharing with colleagues is also a pain point — all data is currently shared via manual uploads to Google Drive, which is confusing and unreliable.
+
+## North Star
+
+The long-term goal is to replace the current manual workflow with:
+1. **Pure Python data pipelines** — one script per data layer, organized in a `pipelines/` folder, running on a schedule or triggered by source data updates
+2. **Custom JS-based map dashboard** — replacing ArcGIS Dashboards with an open-source solution that supports automated data delivery
+
+The ArcGIS workflow has a fundamental ergonomic problem that makes the long-term goal necessary: ArcGIS Online does not support bulk replacement of `master_schools.geojson`, so every new column must be uploaded individually. Automated, live data updates are not feasible under this constraint.
+
+The move to pure Python pipelines also improves: version control of data transformations, data quality testing, reproducibility, and the ergonomics of adding new data layers.
+
+## Guiding Principles
+
+- **Do one thing at a time.** Don't backport parity work and refactor simultaneously — pick one and finish it.
+- **Each pipeline script should have a clear "contract" with the rest of the system:** provide data with a field that matches a join key in `master_schools`, and include only the columns that should join on. The framework handles the rest.
+- **DQ checks are load-bearing.** The join process is fragile without them. Any time a new layer is added to the join, checks should verify that existing fields haven't shifted.
+- **Notebooks stay clean** — commit with no cell outputs. They serve as the human-readable record of data investigation and processing logic.
+
+## Status (2026-07-15)
+
+Active work is happening on branch `feat/pipeline-parity`, tracked in detail in `docs/plans/2026-06-06-001-feat-pipeline-parity-dq-automation-plan.md` (units U1–U10). Progress so far:
+- **Phase 0 (DQ checks) — done.** `check_join()` helper added to `pipelines/join_to_schools.py` and retrofitted onto all existing joins (unit U6).
+- **Phase 1, item 1 (snap points by building code) — done** (unit U2), implemented as the first step in `pipelines/join_to_schools.py`.
+- Processing has moved from the notebook into `pipelines/join_to_schools.py` earlier than the Phase 3 refactor below implies — U2/U6 were built directly against the `.py` file rather than `join_to_schools.ipynb`, since the DQ framework needed a stable target from the start. The full one-file-per-layer split is still pending.
+- GHS survey notebook (Phase 2) has raw processing but is not yet pipeline-ready (no join-ready parquet output or `pipelines/process_ghs_survey_data.py` yet).
+- Remaining Phase 1 parity items (assembly/senate districts, distances, environmental rasters, etc.) not started.
+
+## Phased Plan
+
+### Phase 0: Add DQ checks to `join_to_schools.ipynb` (immediate)
+
+Before any other work begins, add lightweight assertions after each join step so that adding a new layer can't silently corrupt existing fields. Checks should include at minimum:
+- Row count is unchanged after join
+- Null counts on key existing columns haven't changed
+- No duplicate `LocationCode`s introduced
+- Join match rate is above an expected threshold (flag if too low)
+
+This is a small, focused piece of work that protects everything that follows.
+
+### Phase 1: Parity with ArcGIS
+
+Get this repo to the point where it can reproduce the data currently in the live dashboard. Work through André's processing notes in roughly this order:
+
+1. **Snap points by building code** (priority — geometry fix, affects all downstream spatial joins). André's `snap_points_by_BuildingCode.py` aligns school points that share a building to the same location using `Bldg_Code`.
+2. **State Assembly Districts** — spatial join of `nyad_25d` → `AssemDist` field on schools
+3. **State Senate Districts** — spatial join of `nyss_25d` → `StSenDist` field on schools
+4. **School Districts** — verify whether the existing `city_council_districts.ipynb` covers this or if it needs updating
+5. **Distance from peaker plants** — buffer + clip + nearest-distance calculation
+6. **Walking distance from subway** — download from ArcGIS feature server, spatial join for `subway_dist` field
+7. **Hurricane evac zone, heat exposure index, evac center distance, cooling center distance** — 4 fields consolidated in André's `hurricaneEvac_HeatIndex_distEvacCenters_distCoolingCenters.py`
+8. **Air pollution (PM2.5, NO2)** — raster sampling from NYCCAS data → `pm25_2022`, `No2_2022`
+9. **Stormwater flood risk** — ranked join using buffered school points
+10. **On an open street** — 300ft buffer intersect (coordinate with Abhi for the original approach)
+11. **Convert continuous fields to percentile/quartile** — André's `convert_continous_to_percentile_class.py` applies to LL84 energy fields and air pollution fields
+12. **Ventilation and A/C web scraping** — get existing scraping code into the repo
+
+### Phase 2: GHS Survey + Lead Paint (new layers, nearly ready)
+
+Two net-new data layers that are close enough to completion to prioritize before the pipeline refactor. Complete both notebooks and integrate into `join_to_schools.ipynb` to get them into the live ArcGIS dashboard.
+
+- **GHS survey** — finish `process_ghs_survey_data.ipynb`
+    - Thinking for privacy reasons, we could maybe just do a count of the number of respondents at each school who say they want to get involved in the campaign
+    - Could break down complaints from surveys into categories to count easier
+- **Lead paint** — download 2021–2024 data and complete `schools_lead_paint.ipynb`
+
+### Phase 3: Refactor to `pipelines/`
+
+Once parity and GHS survey are complete, refactor all processing into a clean Python pipeline. New data sources added after this point should be built directly in pipeline format, not as notebooks first.
+
+- One `.py` file per data layer in a `pipelines/` folder
+- Each script follows a standard contract: load source data, transform, output a dataframe with a join key and the columns to add — nothing more
+- Each script includes a download/fetch step at the top to codify where source data comes from and make fresh pulls possible
+- A central join script replaces `join_to_schools.ipynb`, calling each pipeline module and assembling `master_schools`
+- DQ checks from Phase 0 become part of the join script, not a notebook
+- `notebooks/` stays as-is for posterity (committed with outputs as a record of data investigation)
+- Centralize processed data in a shared cloud location (S3 or Google Cloud) so colleagues can access it without manual Drive uploads
+
+Open design questions to resolve during this phase:
+- Where does column renaming happen — in each pipeline script or in the join?
+- Where does data type standardization happen?
+- How are schema changes tracked across versions of `master_schools`?
+- Which cloud storage solution works best for colleague access patterns?
+
+### Phase 4: New Data Sources
+
+With the pipeline framework in place, add new data layers directly as `.py` pipeline scripts. Candidates:
+- CUNY Schools (with flag for community colleges, which receive all their funding from the city)
+- Asthma rates
+- Lead pipes
+- [Asbestos](https://data.cityofnewyork.us/Environment/Asbestos-Control-Program-ACP7-/vq35-j9qm/about_data)
+- Green space and schoolyard data
+- Construction report data (may require LLM-based extraction from unstructured reports)
+
+### Phase 5: School Locations Refresh (2026-27 school year)
+
+The new school year's LCGMS data drop should be available as of 2026-07-15 (see https://infohub.nyced.org/in-our-schools/operations/lcgms). We should try to have this data updated before the start of the school year (9/10) if possible.
+
+- Simplify school locations processing: pull only LCGMS schools, geocode all of them with Google Maps, and fall back to DOE source coordinates only if Google returns no result. The current approach of combining multiple sources is too complex to maintain.
+- Ingest the new LCGMS drop through this simplified process.
+- Assess how this changes dashboard insights relative to the current (multi-source) approach.
+- Placed after Phase 4 rather than before: Phase 4's new data layers get a stable, known join anchor (current roster) to build against while that work is distributed, rather than onboarding people onto new layers while the underlying school roster is also changing. The tradeoff is that Phase 1–4 joins will need re-validation against the refreshed roster once this phase completes.
+
+### Phase 6: JS Dashboard + Automated Pipeline
+
+Replace ArcGIS Dashboards with a custom JS-based map dashboard. Architecture TBD — will research options and evaluate against the analytics and filtering capabilities currently in ArcGIS. The Python pipeline from Phase 3 should be the data backend regardless of which frontend is chosen.

--- a/docs/plans/2026-06-06-001-feat-pipeline-parity-dq-automation-plan.md
+++ b/docs/plans/2026-06-06-001-feat-pipeline-parity-dq-automation-plan.md
@@ -1,0 +1,533 @@
+---
+title: "feat: Pipeline parity, DQ checks, and automation for GHS dashboard"
+date: 2026-06-06
+status: active
+origin: docs/brainstorms/2026-06-06-pipeline-parity-and-automation-requirements.md
+plan_type: feat
+---
+
+## Summary
+
+Port André's ~12 missing layers into `pipelines/join_to_schools.py`, add a DQ assertion framework after every join step, validate the upload workflow with lead paint and GHS survey data, and wrap the end-to-end pipeline in a `just update` command with scripted ArcGIS column upload. The outcome is a pipeline that can be run reliably monthly and where adding new layers no longer creates drift between the repo and the live dashboard.
+
+---
+
+## Problem Frame
+
+The repo and the live ArcGIS dashboard have drifted: André added ~12 layers directly in ArcGIS that aren't in the pipeline, and field names between the pipeline output and the ArcGIS feature service don't match. This makes local analysis untrustworthy and every proposed update feel risky. The column-by-column ArcGIS upload process also creates a backlog of fully-processed data (lead paint, GHS survey) that hasn't been shipped.
+
+(see origin: docs/brainstorms/2026-06-06-pipeline-parity-and-automation-requirements.md)
+
+---
+
+## Requirements
+
+**Parity (R1–R3)**
+- R1: All layers from André's processing notes implemented in `pipelines/join_to_schools.py`: snap points by building code, school districts (verify current), assembly districts, state senate districts, subway walking distance, peaker plant distance, hurricane evac zone, heat exposure index, evac center distance, cooling center distance, air pollution (PM2.5 and NO2), stormwater flood risk, open street flag, and percentile/quartile conversions for LL84 energy and air pollution fields
+- R2: Pipeline output column names match the live ArcGIS feature service field names; mismatches surface as errors, not silent renames
+- R3: Snap-points-by-building-code geometry fix applied before any spatial joins run
+
+**DQ checks (R4–R6)**
+- R4: After each join, assertions verify row count unchanged, null counts on key existing columns haven't increased, no duplicate `LocationCode` values
+- R5: Join match rate logged per layer; below-threshold rate halts export with error
+- R6: Pre-export assertion compares output field list against a pinned expected schema
+
+**GHS survey (R7–R8)**
+- R7: `notebooks/process_ghs_survey_data.ipynb` finalized; only field added to join is count of respondents per school willing to get involved; no raw or identifying survey data
+- R8: GHS survey field added to `pipelines/join_to_schools.py`; `process-ghs-survey-data` branch merged and closed
+
+**Upload validation (R9–R10)**
+- R9: Lead paint data added to pipeline join and uploaded to ArcGIS (validates upload workflow end-to-end)
+- R10: GHS survey data uploaded to ArcGIS (second upload validation exercise)
+
+**Pipeline automation (R11–R12)**
+- R11: A single `just update` command runs all processing scripts in sequence and produces updated `master_schools.geojson`
+- R12: `just update` includes DQ checks and aborts with a clear error message on any failure
+
+**Upload automation (R13–R14)**
+- R13: Scripted column-by-column upload reduces manual ArcGIS update to a single command; no full-service overwrite (would break dashboard widget and filter field mappings)
+- R14: New columns tested against a staging dashboard before being applied to the live dashboard
+
+---
+
+## Key Technical Decisions
+
+**KTD1: Snap-points fix runs at pipeline start from immutable source data**
+The fix reads `school_points_with_lcgms.shp` and applies building-code centroid alignment as the first transformation in `join_to_schools.py`. The source file is not modified. This keeps source data canonical and the pipeline self-contained — consistent with how all other joins run inline. (Resolves the planning question about save-once vs. re-run.)
+
+**KTD2: André's parity layers ported inline to `join_to_schools.py`**
+New parity sections are added to the existing join script, following its current pattern of sequential inline transforms. The full one-file-per-layer refactor is explicitly deferred (see Scope Boundaries). New standalone scripts (`process_ghs_survey_data.py`, `process_lead_paint.py`) are created only for layers that require separate pre-processing before the join.
+
+**KTD3: IBO join unchanged for this plan's scope; `Bldg_Owner` is the non-replaceable field**
+The IBO join stays as-is. `building_ownership_description` (`Bldg_Owner` — DOE-owned vs. tax-levy lease) has no independent source. `yearbuilt` (`Bldg_Age`) and other IBO fields are candidates for replacement as independent sources come online — tracked as a separate follow-up, not changed here.
+
+**KTD4: GHS survey output joins via `Loc_Code`; two fields added**
+The survey notebook maps `school_clean` names to `Loc_Code` via LCGMS crosswalk and exports a parquet with one row per school: `ghs_willing_count` (respondents where `q10_get_involved == 1`) and `ghs_total_respondents`. The pipeline joins on `Loc_Code`. No raw names or identifying data in the output.
+
+**KTD5: Column reconciliation gated on ArcGIS REST schema fetch**
+Before implementing U7, fetch the live 179-field list from the ArcGIS feature service REST endpoint (`?f=json`). The target schema is pinned as a JSON file. Pipeline output columns not in the target schema trigger an assertion error with a field diff, not a silent rename.
+
+**KTD6: Upload automation uses `arcgis` Python package with staging-first policy**
+New columns are added to a staging copy of the feature service before the live service. No full-service overwrite. If the `arcgis` package cannot do additive field additions to an existing hosted feature service, fall back to direct ArcGIS REST API calls (`addToDefinition` for schema + `applyEdits` for values).
+
+**KTD7: DQ assertions as a shared helper called after every join**
+A `check_join(before, after, join_name, *, null_sentinel_cols, match_col=None, min_match_rate=None)` helper asserts: row count unchanged, null counts on sentinel columns haven't increased, no `LocationCode` duplicates, match rate on `match_col` is above `min_match_rate`. Failure raises with a descriptive message and halts the pipeline. The DQ helper is added early (before parity work) so every new join section gets a check from day one.
+
+---
+
+## High-Level Technical Design
+
+**Pipeline data flow:**
+
+```mermaid
+flowchart TD
+    SRC[school_points_with_lcgms.shp] -->|snap-points fix| SNAPPED[snapped schools GDF]
+    SNAPPED --> JOIN[join_to_schools.py]
+    JOIN -->|existing joins| EX[boroughs · DACs · election · A/C · vent\ncapacity · BAP · IBO · solar · council · LL84]
+    JOIN -->|new parity layers| NW[assembly/senate districts · school districts\nhurricane evac · OHEI · open street\nsubway dist · peaker dist · evac/cooling dist\nPM2.5 · NO2 · stormwater · percentile conversions]
+    JOIN -->|new data layers| DL[GHS survey count · lead paint]
+    EX & NW & DL --> DQ{DQ checks\npass?}
+    DQ -->|fail| ERR[abort with error]
+    DQ -->|pass| SCHEMA{schema check\npasses?}
+    SCHEMA -->|fail| ERR
+    SCHEMA -->|pass| OUT[master_schools.geojson]
+    OUT --> UPLOAD[upload_to_arcgis.py]
+    UPLOAD --> STAGE[staging dashboard]
+    STAGE -->|verified| LIVE[live dashboard]
+```
+
+**Upload automation sequence:**
+
+```mermaid
+sequenceDiagram
+    participant Script as upload_to_arcgis.py
+    participant REST as ArcGIS REST API
+    participant Stage as Staging Dashboard
+    participant Live as Live Dashboard
+
+    Script->>REST: fetch current field list from feature service
+    Script->>Script: diff pipeline schema against current fields
+    Script->>REST: add new fields to staging feature service schema
+    Script->>REST: bulk-update staging field values
+    Stage->>Stage: manual verification — fields render correctly
+    Script->>REST: add new fields to live feature service
+    Script->>REST: bulk-update live field values
+    Live->>Live: confirm dashboard widgets and filters intact
+```
+
+---
+
+## Output Structure
+
+```
+pipelines/
+├── join_to_schools.py          # expanded with parity layers + DQ helper
+├── process_ghs_survey_data.py  # new: standalone survey processing
+├── process_lead_paint.py       # new: standalone lead paint processing
+└── upload_to_arcgis.py         # new: scripted column-by-column upload
+
+data/
+└── processed_data/
+    ├── ghs_survey_by_school.parquet     # new: GHS join-ready output
+    ├── lead_paint_by_school.parquet     # new: lead paint join-ready output
+    └── schema/
+        └── arcgis_field_target.json     # new: pinned ArcGIS field list
+
+tests/
+└── test_pipeline_dq.py                  # new: DQ helper unit tests
+```
+
+---
+
+## Implementation Units
+
+### Phase 1: Foundation
+
+### U1. GHS survey notebook completion and pipeline-ready output
+
+**Goal:** Finalize `process_ghs_survey_data.ipynb` to produce a join-ready parquet keyed on `Loc_Code` with `ghs_willing_count` and `ghs_total_respondents`, then create `pipelines/process_ghs_survey_data.py` replicating that logic for use in `just update`. Closes the `process-ghs-survey-data` branch.
+
+**Requirements:** R7, R8
+
+**Dependencies:** None
+
+**Files:**
+- `notebooks/process_ghs_survey_data.ipynb`
+- `pipelines/process_ghs_survey_data.py` (new)
+- `data/processed_data/ghs_survey_by_school.parquet` (new output)
+
+**Approach:**
+- Add a school-name → `Loc_Code` mapping step: normalize both the survey's `school_clean` field and LCGMS school names (lowercase, strip punctuation), then match. Load the LCGMS crosswalk from `data/processed_data/school_points_with_lcgms.shp`.
+- Aggregate to school level: `ghs_willing_count = sum(q10_get_involved)`, `ghs_total_respondents = count(responses)`. Use `Loc_Code` as the join key (per-school, not per-building).
+- Export parquet with only `Loc_Code`, `ghs_willing_count`, `ghs_total_respondents` — no raw names, grades, or other identifying columns.
+- Log match rate of survey school names to LCGMS; flag if below 80%.
+
+**Patterns to follow:** Solar readiness notebook → parquet export pattern in `04_solar_readiness_assessment.ipynb`; column naming style in `join_to_schools.py` rename dict.
+
+**Test scenarios:**
+- Output parquet contains zero `Loc_Code` values that don't appear in `school_points_with_lcgms`
+- `ghs_willing_count` is non-negative for all rows; `ghs_total_respondents >= ghs_willing_count` for all rows
+- No raw respondent names or PII present in the output
+- LaGuardia High School maps to the expected `Loc_Code` (known survey respondent school)
+- Match rate is logged; running on the 3/18/2026 data achieves at least 80% school name resolution
+
+**Verification:** Output parquet loads cleanly; row count equals distinct schools in survey with at least one response; `ghs_willing_count` correct for a spot-checked school.
+
+---
+
+### U2. Snap-points geometry fix as pipeline first step
+
+**Goal:** Implement the `snap_points_by_BuildingCode` logic as the first transformation in `join_to_schools.py`, aligning school points that share a `Bldg_Code` to a shared centroid before any spatial joins run.
+
+**Requirements:** R3
+
+**Dependencies:** None (runs first in pipeline)
+
+**Files:**
+- `pipelines/join_to_schools.py`
+
+**Approach:**
+- The file `notebooks/andre_working/snap_points_by_BuildingCode.py` was committed with the wrong content (a TerraCarbon SOC raster script). Implement from André's written description in `docs/Andre Processing Notes.md` item 1: group school points by `Bldg_Code`, compute the centroid of each group's geometries, update the `geometry` (and `Lat`/`Long` fields if present) for all rows in the group to the centroid.
+- Insert immediately after loading `school_points_with_lcgms.shp`, before the boroughs join. The source shapefile is not modified.
+- When André provides the corrected script, compare and reconcile any differences.
+
+**Patterns to follow:** Existing groupby/geometry operations in geopandas; CRS preservation after geometry reassignment.
+
+**Test scenarios:**
+- After the fix, all rows sharing the same `Bldg_Code` have identical geometry
+- Row count is unchanged from the source shapefile
+- A building code known to have multiple school points (identify one during implementation) converges to a single shared geometry
+- CRS of the schools GDF is unchanged after the fix
+
+**Verification:** Assert passes for at least one multi-school building; total row count unchanged.
+
+---
+
+### Phase 2: DQ Framework (added before parity work so every new join benefits)
+
+### U6. DQ assertion helper and per-join check integration
+
+**Goal:** Add a `check_join` helper function to `join_to_schools.py` and call it after every existing and new join step.
+
+**Requirements:** R4, R5, R12
+
+**Dependencies:** U2 (snap-points as first join step; helper is called after each subsequent section)
+
+**Files:**
+- `pipelines/join_to_schools.py`
+- `tests/test_pipeline_dq.py` (new)
+
+**Approach:**
+- Define `check_join(before, after, join_name, *, null_sentinel_cols, match_col=None, min_match_rate=None)` near the top of `join_to_schools.py`:
+  - Assert `len(after) == len(before)` — row count unchanged
+  - For each col in `null_sentinel_cols`: assert `after[col].isna().sum() <= before[col].isna().sum()`
+  - Assert no duplicate `LocationCode`/`Loc_Code` values in `after`
+  - If `match_col` provided: compute `rate = after[match_col].notna().mean()`; log it; if below `min_match_rate`, raise with the actual rate in the message
+- Retrofit after every existing join section (boroughs, DACs, election, A/C, vent, capacity, BAP, IBO, solar, council, school districts, LL84). Consolidate the existing ad-hoc asserts into this helper.
+- Match rate thresholds per join type: 0.99 for key-based tabular joins (A/C, BAP, solar); 0.80 for spatial joins with known geographic gaps; 0.50 for limited-coverage datasets (IBO). Document the threshold choice in a comment above each call.
+
+**Test scenarios (in `tests/test_pipeline_dq.py`):**
+- `check_join` raises `AssertionError` when `after` has more rows than `before` (many-to-one join without dedup)
+- `check_join` raises when a sentinel column gains nulls in `after`
+- `check_join` raises when `after` contains duplicate `Loc_Code` values
+- `check_join` raises when match rate is below `min_match_rate`; error message includes the actual rate
+- `check_join` passes silently when all conditions are met
+- `check_join` logs match rate to stdout even when above threshold
+
+**Verification:** Running the pipeline end-to-end with the helper retrofitted to all existing joins completes without assertion failures on current data.
+
+---
+
+### Phase 3: Parity Layers
+
+### U3. Polygon zone joins — assembly districts, senate districts, school districts, hurricane evac, OHEI, open street flag
+
+**Goal:** Add six polygon-join sections to `join_to_schools.py` producing `AssemDist`, `StSenDist`, `SchoolDist` (verify/update), `hurricane_evacZone`, `OHEI`, and `on_open_street` fields.
+
+**Requirements:** R1
+
+**Dependencies:** U2, U6
+
+**Files:**
+- `pipelines/join_to_schools.py`
+- `data/raw_data/NYC Planning/` (assembly: `nyad_25d`, senate: `nyss_25d` — download steps included)
+
+**Approach:**
+- **Assembly and senate districts**: Download `nyad_25d` and `nyss_25d` from NYC OpenData (URLs in André's notes); reproject to schools CRS; `sjoin(..., predicate="within")`; produce `AssemDist` and `StSenDist` fields. Codify download URL as a comment.
+- **School districts**: The pipeline already has a school districts join (`nysd_26a`). Verify the dataset version against what André used (André's notes mention he re-did this with a more updated version). If stale, update to current version from NYC OpenData. This is a verify step, not a guaranteed change.
+- **Hurricane evac zone and OHEI**: Adapt `notebooks/andre_working/hurricaneEvac_HeatIndex_distEvacCenters_distCoolingCenters.py` — the spatial join sections (Sections 4 and 5) for `hurricane_evacZone` and `OHEI`. Replace Windows paths with repo-relative paths; use left join; call `check_join` after each.
+- **Open street flag**: Stub section with a TODO comment pending Abhi's data source and 300ft buffer methodology. Do not block parity work on it — leave `on_open_street` null in the output until resolved.
+- Call `check_join` after each section with appropriate sentinel columns.
+
+**Patterns to follow:** Existing `sjoin` sections in `join_to_schools.py` — CRS alignment before join, `drop(columns=["index_right"])` after join, left join semantics.
+
+**Test scenarios:**
+- Row count unchanged after each polygon join
+- No school has a null `AssemDist` or `StSenDist` (every NYC school falls within a district)
+- A school known to be in a hurricane evacuation zone has the expected `hurricane_evacZone` value
+- Null counts on pre-existing columns (e.g., `ZohrPrimR1`, `in_dac`) unchanged after each join
+- Covers R1 / AE for assembly districts: `AssemDist` present and non-null for all schools after join
+
+**Verification:** Five new fields present (`on_open_street` may be null pending Abhi); no null district values; `check_join` passes for each section.
+
+---
+
+### U4. Distance fields — subway, peaker plant, evac centers, cooling centers
+
+**Goal:** Add four distance calculation sections to `join_to_schools.py` producing `subway_dist`, `peaker_mi`, `evacCenters_distance_mi`, and `cooling_centers_distance_mi`.
+
+**Requirements:** R1
+
+**Dependencies:** U2, U6
+
+**Files:**
+- `pipelines/join_to_schools.py`
+- `notebooks/andre_working/dist_to_subway_processing.py` (reference)
+- `notebooks/andre_working/hurricaneEvac_HeatIndex_distEvacCenters_distCoolingCenters.py` (reference — Sections 6 and 7)
+- `notebooks/andre_working/download_geojson_from_arc_server.py` (utility for subway layer)
+- `data/raw_data/peaker_plants_all.geojson` (already present)
+
+**Approach:**
+- **Subway distance**: Download walking-distance polygons from the ArcGIS feature server URL in André's notes using the `download_geojson_from_arc_server.py` pattern; `sjoin` points within polygons to get `WalkingB_1`; create `subway_dist` as a standardized text field ("0-5 min", "5-10 min", ">10 min") following `dist_to_subway_processing.py`.
+- **Peaker plant distance**: Use existing `data/raw_data/peaker_plants_all.geojson`; buffer schools by 5 miles; clip plants to buffer; `sjoin_nearest` in EPSG:2263 (NYC feet); convert to miles → `peaker_mi`.
+- **Evac and cooling center distances**: Adapt Sections 6 and 7 of `hurricaneEvac_HeatIndex_distEvacCenters_distCoolingCenters.py`; download cooling centers from ArcGIS feature server URL; `sjoin_nearest` in EPSG:2263 for both; convert to miles.
+- All distance calculations: project to EPSG:2263 for computation, convert to miles, reproject back to original CRS.
+
+**Patterns to follow:** `sjoin_nearest` already used in `join_to_schools.py` (election results fallback) — follow the same CRS round-trip pattern.
+
+**Test scenarios:**
+- Row count unchanged after each distance calculation
+- `subway_dist` contains only expected text values; no raw numeric or null values (nulls replaced with ">10 min")
+- All schools have a non-null `peaker_mi` value
+- `evacCenters_distance_mi` and `cooling_centers_distance_mi` are non-negative for all schools
+- Null counts on pre-existing columns unchanged after each section
+
+**Verification:** Four distance fields present; all non-null; no negative values; known Manhattan school has `subway_dist` of "0-5 min" or "5-10 min".
+
+---
+
+### U5. Environmental rasters, stormwater ranked join, and percentile/quartile conversions
+
+**Goal:** Add PM2.5 and NO2 raster sampling, stormwater flood risk ranked join, and percentile/quartile field conversions for 13 continuous fields.
+
+**Requirements:** R1
+
+**Dependencies:** U2, U3, U6
+
+**Files:**
+- `pipelines/join_to_schools.py`
+- `notebooks/andre_working/process_air_pollution_and_join.py` (reference)
+- `notebooks/andre_working/storm_water_ranked_join.py` (reference)
+- `notebooks/andre_working/convert_continous_to_percentile_class.py` (reference)
+- `pyproject.toml` (add `rasterio` dependency)
+
+**Approach:**
+- **Air pollution**: Sample NYCCAS rasters (`aa14_pm300m` for PM2.5, `aa14_no2300m` for NO2) at school point locations using `rasterio`; add `pm25_2022` and `no2_2022` continuous fields. Include a comment with the NYC OpenData download URL for the raster archive.
+- **Stormwater**: The raw stormwater download has filename-length unzip issues (noted by André). Use the pre-processed layer from André's Google Drive link; add it to `data/raw_data/` with provenance documented in a comment. Buffer school points by 300 feet; ranked join assigns the highest flood risk polygon (rank 1 = most severe) to each school via the pattern in `storm_water_ranked_join.py`; produces `Flood_Scenario` and `Stormwater_Flood_Risk`.
+- **Percentile/quartile conversion**: After all joins, convert 13 continuous fields (air pollution: `pm25_2022`, `no2_2022`; LL84: energy star score, GHG intensity, site EUI, percent electricity, 8 fuel fields) to quartile categories using `pd.qcut(q=4)`. Null values → "No data" string. Quartile column names follow the `_pct` suffix convention from André's script.
+- Apply conversion as the last step before the rename dict and export block.
+
+**Patterns to follow:** Rasterio point sampling from `process_air_pollution_and_join.py`; stormwater buffer + ranked join from `storm_water_ranked_join.py`; quartile logic from `convert_continous_to_percentile_class.py`.
+
+**Test scenarios:**
+- `pm25_2022` and `no2_2022` non-null for all schools (NYCCAS rasters cover all of NYC)
+- `Stormwater_Flood_Risk` values are in {1, 2, 3, 4, null}; null only for schools outside all flood polygons
+- `Flood_Scenario` values match André's four scenario strings exactly
+- All 13 `_pct` quartile columns present; values in {0, 1, 2, 3, "No data"}
+- Quartile distribution is approximately 25% per non-null bucket for a continuous field
+- Null counts on pre-existing columns unchanged
+
+**Verification:** All new fields present; raster sampling returns plausible values for known high-pollution neighborhoods (e.g., South Bronx); quartile buckets roughly balanced.
+
+---
+
+### Phase 4: Schema Alignment and New Data Layers
+
+### U7. Column name reconciliation and pinned schema validation
+
+**Goal:** Compare pipeline output schema against the live ArcGIS 179-field schema, reconcile all mismatches into the `shortened_cols` rename dict, and add a pre-export assertion that output columns exactly match a pinned target.
+
+**Requirements:** R2, R6
+
+**Dependencies:** U3, U4, U5 (all parity fields must be in the output first)
+
+**Files:**
+- `pipelines/join_to_schools.py`
+- `data/processed_data/schema/arcgis_field_target.json` (new — pinned field list)
+
+**Approach:**
+- **Prerequisite step before implementation**: Fetch the ArcGIS feature service field list from the REST endpoint (`?f=json`; URL in `docs/plan.md`). Extract all `fields[].name` values. Save to `data/processed_data/schema/arcgis_field_target.json`. This is the target schema.
+- **Comparison**: Run the pipeline to produce a candidate output; compare column names against the target. Three buckets: (a) pipeline → ArcGIS name mapping → add to `shortened_cols`; (b) pipeline columns absent from ArcGIS → decide: upload backlog (new) or drop (stale); (c) ArcGIS columns absent from pipeline → remaining parity gaps.
+- **IBO fields**: If `building_ownership_description` and `yearbuilt` are absent from ArcGIS, add them to an upload backlog note — do not drop. If present with different names, add renames.
+- **Schema assertion**: After rename, add pre-export check: assert pipeline output columns equal the pinned target set. Column added unexpectedly → assertion error with the extra column named. Column dropped → assertion error with the missing column named.
+- `shortened_cols` in `join_to_schools.py` remains the single source of truth for all renames.
+
+**Test scenarios:**
+- Pipeline output after rename contains `ZohrPrimR1` (not `ZohranFirstRoundFrac`) — the confirmed mismatch is resolved
+- Schema assertion passes on a clean run
+- Adding a spurious column to the output triggers the assertion error naming the unexpected column
+- Removing a column from the rename dict triggers the assertion error naming the missing column
+
+**Verification:** All output columns match the pinned ArcGIS field names; `shortened_cols` reviewed against fetched schema; no unintended columns in output; pinned JSON committed to the repo.
+
+---
+
+### U8. Lead paint notebook completion and GHS survey + lead paint join integration
+
+**Goal:** Complete `notebooks/schools_lead_paint.ipynb` to produce a join-ready parquet; create `pipelines/process_lead_paint.py`; add both GHS survey and lead paint sections to `join_to_schools.py`.
+
+**Requirements:** R8, R9 (pipeline integration portion)
+
+**Dependencies:** U1 (GHS survey parquet), U6 (DQ helper), U7 (schema validation in place)
+
+**Files:**
+- `notebooks/schools_lead_paint.ipynb`
+- `pipelines/process_lead_paint.py` (new)
+- `data/processed_data/lead_paint_by_school.parquet` (new output)
+- `pipelines/join_to_schools.py`
+
+**Approach:**
+- **Lead paint notebook**: Fetch 2021–2024 lead paint hazard data from DOE/DOH sources (identify the appropriate NYC OpenData endpoint); aggregate to building code (e.g., violation count, most recent inspection date, hazard present flag); export as parquet keyed on `Bldg_Code`. Create `pipelines/process_lead_paint.py` replicating the notebook logic.
+- **GHS survey join**: Read `ghs_survey_by_school.parquet`; merge on `Loc_Code` with `how="left"`; call `check_join`.
+- **Lead paint join**: Read `lead_paint_by_school.parquet`; merge on `Bldg_Code` with `how="left"`; call `check_join`.
+- Add both sections after all existing joins, before the rename dict and export block.
+
+**Patterns to follow:** Existing pandas merge pattern for tabular data (A/C, ventilation); `check_join` call pattern from U6; parquet export pattern from U1.
+
+**Test scenarios:**
+- Row count unchanged after GHS survey join; after lead paint join
+- Null counts on pre-existing columns unchanged after each join
+- `ghs_willing_count` is non-null for schools known to appear in the survey; null for schools with no responses
+- Lead paint fields are non-null for at least some buildings (validates data presence)
+- `ghs_total_respondents >= ghs_willing_count` holds for all non-null rows after join
+
+**Verification:** Both fields present in output GeoJSON; row count unchanged end-to-end; `check_join` passes for both new joins.
+
+---
+
+### Phase 5: Automation
+
+### U9. `just update` pipeline command
+
+**Goal:** Add a `just update` recipe that runs all processing scripts in sequence, produces updated `master_schools.geojson`, and propagates DQ failures as non-zero exit codes.
+
+**Requirements:** R11, R12
+
+**Dependencies:** U6 (DQ helper halts pipeline on failure), U8 (all data layers in pipeline)
+
+**Files:**
+- `justfile`
+
+**Approach:**
+- The `just update` recipe runs in order: `pipelines/process_ghs_survey_data.py`, `pipelines/process_lead_paint.py`, `pipelines/join_to_schools.py`. Future standalone processing scripts follow the same pattern.
+- DQ failures in `join_to_schools.py` already raise `AssertionError` which exits non-zero — `just` propagates this automatically.
+- Each step prints a clear progress header (e.g., "--- Running GHS survey processing ---") so operators know where a failure occurred.
+- Add `_ensure-venv` prerequisite consistent with existing just recipes.
+
+**Test scenarios:**
+- `just update` runs end-to-end and produces a valid, parseable `master_schools.geojson`
+- Running `just update` twice produces identical output (idempotent given unchanged inputs)
+- Injecting a null into a sentinel field in the test data causes `just update` to exit non-zero with a readable error
+
+**Verification:** `just update` completes without errors on current data; output GeoJSON file timestamp is updated; output file is valid GeoJSON.
+
+---
+
+### U10. Scripted column-by-column ArcGIS upload
+
+**Goal:** Create `pipelines/upload_to_arcgis.py` that adds new columns to an existing ArcGIS hosted feature service without full overwrite, with a staging-first workflow.
+
+**Requirements:** R9 (upload portion), R10, R13, R14
+
+**Dependencies:** U7 (schema aligned), U8 (new columns in pipeline output), U9 (clean output from `just update`)
+
+**Files:**
+- `pipelines/upload_to_arcgis.py` (new)
+- `pyproject.toml` (add `arcgis` dependency)
+- `.env.example` (add ArcGIS credentials and item IDs)
+
+**Approach:**
+- Script accepts: path to `master_schools.geojson`, and a `--target staging|live` flag. Target feature service item IDs and credentials come from environment variables.
+- Logic: (1) fetch current field list from the target feature service; (2) diff against `master_schools.geojson` columns; (3) for each new column, add field to the service schema; (4) bulk-update values using the `arcgis` package. Only additive — does not modify or overwrite existing fields.
+- If `arcgis` package cannot do additive field additions without a full overwrite: fall back to ArcGIS REST API directly (`addToDefinition` for schema additions, `applyEdits` for value updates).
+- Include a `--dry-run` flag that prints the columns to be added without making API calls.
+- Staging workflow: run `--target staging` first (satisfies R14), verify in the dashboard, then `--target live`.
+- Add `ARCGIS_USERNAME`, `ARCGIS_PASSWORD` (or `ARCGIS_TOKEN`), `ARCGIS_ITEM_ID_STAGING`, `ARCGIS_ITEM_ID_LIVE` to `.env.example`.
+
+**Patterns to follow:** Existing `.env` usage in the repo (Google Maps key); no existing ArcGIS API code — reference `arcgis` Python package documentation.
+
+**Test scenarios:**
+- Script correctly identifies columns in `master_schools.geojson` absent from the current ArcGIS schema
+- Script does not attempt to modify or overwrite existing columns
+- `--dry-run` outputs the list of columns to add without making API calls
+- `--target staging` does not affect the live feature service item
+- Script exits with a clear error if any required env var is missing
+- Running the script a second time with no new columns produces a no-op (nothing to add)
+
+**Verification:** After `--target staging` run, the staging dashboard shows new columns populated for spot-checked schools; live dashboard unchanged; after `--target live` run, live dashboard shows new columns.
+
+---
+
+## Scope Boundaries
+
+### In scope
+- All 14 requirements from the origin document (R1–R14)
+- Lead paint notebook completion (prerequisite for R9)
+- School districts dataset version check/update (part of R1)
+- Open street flag stub (R1) — full implementation pending Abhi's data/methodology
+
+### Deferred to follow-up work
+- Full one-file-per-layer pipeline refactor (north star from `docs/plan.md`) — deferred until parity and automation are complete and the pattern is established
+- IBO field migration to independent data sources — ongoing separate workstream; `Bldg_Owner` retained; other IBO fields reviewed as replacements come online
+- Ventilation/A/C web scraping — requires getting existing scraping code into the repo first (separate workstream)
+- School locations simplification (LCGMS-only + Google Maps) — deferred until before next LCGMS data drop in 2026
+- Net-new data layers (green schoolyard, lead pipes, asbestos, etc.) — start after upload workflow is validated
+- Open street flag full implementation — requires Abhi's data source and 300ft buffer approach
+
+### Outside this product's identity
+- ArcGIS dashboard replacement — remains a long-term aspiration; no comparable open-source alternative available within current constraints
+
+---
+
+## Risks & Dependencies
+
+**`snap_points_by_BuildingCode.py` is the wrong file**
+The file at `notebooks/andre_working/snap_points_by_BuildingCode.py` contains a TerraCarbon SOC raster script, not the school snap-points code. U2 implements the logic from André's written description in `docs/Andre Processing Notes.md`. André has been asked to send the corrected file; reconcile U2's implementation against it when received.
+
+**`arcgis` package column-addition capability is unverified**
+The upload approach (R13) assumes the `arcgis` Python package can add fields to an existing hosted feature service without a full overwrite. Verify this before starting U10. If it cannot, the fallback is direct REST API calls — this changes U10's implementation significantly but not its interface or the staging-first policy.
+
+**Open street flag depends on Abhi**
+The `on_open_street` field (R1) requires Abhi's data source and 300ft buffer methodology. U3 includes a stub; the field remains null in the output until Abhi provides the source.
+
+**Column name reconciliation requires the ArcGIS field list**
+U7 cannot be fully scoped until the live field list is fetched. The fetch is the first step of U7. The diff may reveal additional parity gaps beyond the known `ZohranFirstRoundFrac` → `ZohrPrimR1` mismatch.
+
+**Lead paint notebook is incomplete**
+`notebooks/schools_lead_paint.ipynb` is an untracked file with no corresponding output in `data/processed_data/`. Lead paint notebook completion is included in U8's scope, not a pre-condition for this plan.
+
+**Stormwater raw data has filename-length unzip issues**
+André's notes mention the raw stormwater download zip fails to unzip due to overly long filenames. The pre-processed layer from André's Google Drive is the practical path. Commit it to `data/raw_data/` with provenance documented.
+
+---
+
+## Open Questions
+
+**Deferred to implementation:**
+- Match rate thresholds per layer — establish after first pipeline run reveals actual rates. Starting defaults: 0.99 for exact key joins (A/C, BAP, solar), 0.80 for spatial joins with geographic gaps (stormwater, subway), 0.50 for limited-coverage datasets (IBO). Adjust and document the rationale per join.
+- Lead paint join key — `Bldg_Code` is most likely, but verify against the lead paint source data structure during U8.
+- ArcGIS item IDs for staging and live feature services — configure in `.env` at the start of U10.
+- IBO field ArcGIS status — the full field diff in U7 will determine whether `Bldg_Owner`, `Bldg_Age`, and `yearbuilt` appear in the live ArcGIS schema. If absent, add to the upload backlog note in U10.
+- School districts dataset version — verify during U3 whether the existing `nysd_26a` join is current or needs updating to André's newer version.
+
+---
+
+## Sources & Research
+
+- André's processing notes: `docs/Andre Processing Notes.md`
+- André's reference scripts (all with Windows hardcoded paths, adapt for repo): `notebooks/andre_working/`
+- Current pipeline: `pipelines/join_to_schools.py`
+- Live ArcGIS feature service (179 fields, REST queryable): URL documented in `docs/plan.md`
+- ArcGIS dashboard item: URL documented in `docs/plan.md`
+- Project plan and north star: `docs/plan.md`
+- Origin requirements document: `docs/brainstorms/2026-06-06-pipeline-parity-and-automation-requirements.md`

--- a/notebooks/schools_lead_paint.ipynb
+++ b/notebooks/schools_lead_paint.ipynb
@@ -1,0 +1,184 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9206f96d",
+   "metadata": {},
+   "source": [
+    "# Lead Paint\n",
+    "\n",
+    "Data from: https://www.schools.nyc.gov/school-life/space-and-facilities/space-and-facilities-reports/lead-based-paint\n",
+    "\n",
+    "According to DOE, monitoring and remediation of lead paint in school buildings only \"applies to all buildings serving kids under six built before 1985\". This data only contains \"results of the inspections for all classrooms serving students in first grade or under\".\n",
+    "\n",
+    "Standard response protocols for lead-based paint are only initiated when there is paint peeling already. See this description of protocols from the above described in the webpage from the above link:\n",
+    "\n",
+    "\n",
+    "If your child is under the age of six and their school was built before 1985:\n",
+    "- Their classroom is inspected and if there is any peeling paint, it is addressed\n",
+    "- If there is peeling paint, an independent contractor tests whether the paint is lead-based paint, and, if it is, a safety plan is developed.\n",
+    "- If the paint is lead-based paint or is paint of an unknown origin, the peeling paint is stripped and then sealed with a certified primer and painted over. Deteriorating paint on impact points, such as radiators and window sills is completely removed. This is abatement. If this work is occurring in a classroom, students are relocated in the interim. If it is occurring in a common space, it is made inaccessible to students so the work is safe.\n",
+    "- Once the lead-based paint has been abated, an independent certified inspector technician takes dust wipes that are tested to make sure the room is safe for children to reenter. This completes remediation.\n",
+    "- Custodian Engineers continue to visually inspect classrooms regularly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13ec3cfc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b1660e87",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: what is a cohort and why are there 3 a year?\n",
+    "# TODO: download data for last 5 years and add to the below"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e39bb57",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cohort1_2025_fp = '../data/raw_data/DOE/Lead Paint/2025-cohort-1-lbp-report-final.xlsx'\n",
+    "cohort2_2025_fp = '../data/raw_data/DOE/Lead Paint/2025-cohort-2-lbp-report-final.xlsx'\n",
+    "cohort3_2025_fp = '../data/raw_data/DOE/Lead Paint/2025-cohort-3-lbp-report-final.xlsx'\n",
+    "\n",
+    "c1_25_df = pd.read_excel(cohort1_2025_fp)\n",
+    "c2_25_df = pd.read_excel(cohort2_2025_fp)\n",
+    "c3_25_df = pd.read_excel(cohort3_2025_fp)\n",
+    "\n",
+    "c1_25_df = c1_25_df.drop(columns=['Unnamed: 0', 'BOROUGH', 'GEOGRAPHICAL DISTRICT'])\n",
+    "c2_25_df = c2_25_df.drop(columns=['Unnamed: 0', 'BOROUGH', 'GEOGRAPHICAL DISTRICT'])\n",
+    "c3_25_df = c3_25_df.drop(columns=['BOROUGH', 'GEOGRAPHICAL DISTRICT'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "476b38c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_cohorts_25 = pd.concat([c1_25_df, c2_25_df, c3_25_df])\n",
+    "all_cohorts_25['BUILDING CODE'] = all_cohorts_25['BUILDING CODE'].str.strip().str.upper()\n",
+    "all_cohorts_25['ROOM'] = all_cohorts_25['ROOM'].str.strip().str.upper()\n",
+    "# Check that building codes are all standardized\n",
+    "assert (all_cohorts_25['BUILDING CODE'].str.contains(r'^[XQMKR]\\d{3}$')).all()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "509133a4",
+   "metadata": {},
+   "source": [
+    "This data doesn't include any un-remediated classrooms, which means they're only reporting _after_ abatement is done. I personally think this is a bit underhanded, because it gives us no sense of how many schools are actively undergoing lead abatement or where lead abatement might not have occurred even after a long time after it was found. We have no way of calculating the average response time of abatement after initial reporting.\n",
+    "\n",
+    "Given this, my curren thought is that the best we can do with this data is show the schools where the highest number of abatement cases has occurred within the last N years (thinking maybe last 5 years?). The intention here would be to show the schools with the most lead contamination. However, that's not actually what we're able to do with this data if they never update until abatement has already occurred. Instead, we get survivor bias, which may reflect the schools that are (1) most on top of their requirements to detect lead and/or (2) most effective in abating lead once it is found.\n",
+    "\n",
+    "In addition, this data is very limited, since it only covers schools with students in first grade or younger. We have no sense of the lead exposure for students more than 6 years old.\n",
+    "\n",
+    "I'd like to do some searching around online to see if there's something like the IBO report from an independent body that makes sense of this data vis-a-vis student health. Ideally, I'd like to find a way to approximate how much unabated lead paint is in all school buildings using this data or other datasets. It might be best to just flag schools built before 1965 or 1985 (DOE adds a 20-year buffer for the buildings it inspects) as likely to have lead paint.\n",
+    "\n",
+    "Still need to find lead pipe data. I know there's data on this for regular buildings in NYC (saw a map once). Maybe that source or another similar one could be used to locate lead pipes in schools?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15ca9afa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NOTE: it's suspicious to me that there are NO un-remediated classrooms. That suggests that in-progress work is not being reported, and it's only reported when it's complete.\n",
+    "\n",
+    "# Not seeing any logically contradictory results, which is nice. If there's deteriorated paint and lead is in it, 'REMEDIATION REQUIRED' is always \"YES\"\n",
+    "all_cohorts_25[\n",
+    "    # (all_cohorts_25['DETERIORATED PAINT']=='NO')\n",
+    "    # &\n",
+    "    (all_cohorts_25['PRESENCE OF LBP IN DETERIORATED PAINT']=='YES')\n",
+    "    &\n",
+    "    (all_cohorts_25['REMEDIATION COMPLETE']!='YES')\n",
+    "    # &\n",
+    "    # (all_cohorts_25['REMEDIATION REQUIRED']!='YES')\n",
+    "    ]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "344fc8c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check that there are no rooms where more than 1 instance of LBP was found\n",
+    "# This allows us to calculate the proportion of rooms with LBP by just dividing unique rooms by instances of LBP\n",
+    "assert not (all_cohorts_25.groupby(['BUILDING CODE', 'ROOM'])['PRESENCE OF LBP IN DETERIORATED PAINT'].transform(lambda s: (s=='YES').sum()) > 1).any()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f0fe6462",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lbp_per_school_bldg = all_cohorts_25.groupby('BUILDING CODE').agg(\n",
+    "        {\n",
+    "            'ROOM': 'nunique', \n",
+    "            'PRESENCE OF LBP IN DETERIORATED PAINT': lambda s: (s=='YES').sum()\n",
+    "        }\n",
+    "    ).rename(columns={'ROOM': 'rooms', 'PRESENCE OF LBP IN DETERIORATED PAINT': 'lbp_found'})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "606d29b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lbp_per_school_bldg[lbp_per_school_bldg['lbp_found']>0].sort_values('lbp_found', ascending=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "95ebb8f0",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (.venv) zohran-ghs-dashboard",
+   "language": "python",
+   "name": "zohran-ghs-dashboard"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pipelines/join_to_schools.py
+++ b/pipelines/join_to_schools.py
@@ -1,3 +1,10 @@
+"""
+Assemble master_schools.geojson by joining all data layers onto school points.
+
+Each join is a standalone function that takes a GeoDataFrame and returns one.
+Call build_master_schools() to run the full pipeline.
+"""
+
 import os
 import zipfile
 
@@ -5,237 +12,9 @@ import geopandas as gpd
 import pandas as pd
 
 # ---------------------------------------------------------------------------
-# Load school points
+# Column rename map (shapefile-era 10-char names; deferred full rename to U10)
 # ---------------------------------------------------------------------------
-schools = gpd.read_file("data/processed_data/school_points_with_lcgms.shp")
-
-# ---------------------------------------------------------------------------
-# Join boroughs
-# ---------------------------------------------------------------------------
-boroughs = gpd.read_file("data/raw_data/NYC Planning/Boroughs/nybb_25c/nybb.shp")[
-    ["BoroName", "geometry"]
-].to_crs(schools.crs)
-master_schools = gpd.sjoin(schools, boroughs, how="left", predicate="within").drop(
-    columns=["index_right"]
-)
-
-# ---------------------------------------------------------------------------
-# Join DACs
-# ---------------------------------------------------------------------------
-dacs = gpd.read_file("data/processed_data/dac_nyc_lite.geojson")
-
-# Check that no schools sit exactly on a DAC border
-assert (
-    schools.geometry.apply(dacs.union_all().covers).sum()
-    == schools.geometry.within(dacs.union_all()).sum()
-)
-
-master_schools = gpd.sjoin(schools, dacs, how="left", predicate="within")
-master_schools.drop(columns=["index_right", "county", "geoid"], inplace=True)
-master_schools["dac_designation"] = master_schools["dac_designation"].fillna(False)
-
-# ---------------------------------------------------------------------------
-# Join election results (nearest-neighbor fallback for unmatched schools)
-# ---------------------------------------------------------------------------
-primary_results = gpd.read_file("data/processed_data/zohran_first_round_frac.geojson")
-
-master_schools_og_crs = master_schools.crs
-primary_results_og_crs = primary_results.crs
-master_schools = master_schools.to_crs("EPSG:3857")
-primary_results = primary_results.to_crs("EPSG:3857")
-
-master_schools = gpd.sjoin(
-    master_schools, primary_results, how="left", predicate="within"
-).drop(columns=["index_right"])
-
-unmatched_mask = master_schools["ZohranFirstRoundFrac"].isna()
-unmatched_schools = master_schools[unmatched_mask].copy()
-print(
-    f"Found {unmatched_mask.sum()} schools without polygon matches, "
-    "using nearest neighbor..."
-)
-
-nearest_join = gpd.tools.sjoin_nearest(
-    unmatched_schools.drop(columns="ZohranFirstRoundFrac"), primary_results, how="left"
-)
-master_schools.loc[unmatched_mask, "ZohranFirstRoundFrac"] = nearest_join[
-    "ZohranFirstRoundFrac"
-].values
-
-assert not master_schools["ZohranFirstRoundFrac"].isna().any()
-
-master_schools = master_schools.to_crs(master_schools_og_crs)
-primary_results = primary_results.to_crs(primary_results_og_crs)
-
-# ---------------------------------------------------------------------------
-# Join A/C data
-# ---------------------------------------------------------------------------
-no_ac_summary = pd.read_csv("data/processed_data/no_ac_summary.csv")
-
-ct_bldg_codes_missing_from_ac_data = (
-    master_schools["Bldg_Code"].nunique() - no_ac_summary["BuildingCode"].nunique()
-)
-
-master_schools = master_schools.merge(
-    no_ac_summary, left_on="Bldg_Code", right_on="BuildingCode", how="left"
-).drop(columns=["BuildingCode"])
-
-assert (
-    master_schools.drop_duplicates(subset=["Bldg_Code"])["CLS_No_AC"].isna().sum()
-    == ct_bldg_codes_missing_from_ac_data
-)
-
-# ---------------------------------------------------------------------------
-# Join ventilation data
-# ---------------------------------------------------------------------------
-missing_ventilation_summary = pd.read_csv(
-    "data/processed_data/missing_ventilation_summary.csv"
-)
-
-ct_bldg_codes_missing_from_vent_data = (
-    master_schools["Bldg_Code"].nunique()
-    - missing_ventilation_summary["BuildingCode"].nunique()
-)
-
-master_schools = master_schools.merge(
-    missing_ventilation_summary,
-    left_on="Bldg_Code",
-    right_on="BuildingCode",
-    how="left",
-).drop(columns=["BuildingCode"])
-
-assert (
-    master_schools.drop_duplicates(subset=["Bldg_Code"])["CLS_No_VT"].isna().sum()
-    == ct_bldg_codes_missing_from_vent_data
-)
-
-# ---------------------------------------------------------------------------
-# Join building capacity + utilization
-# ---------------------------------------------------------------------------
-bldg_capacity_utilization = pd.read_csv(
-    "data/processed_data/bldg_capacity_utilization.csv"
-)
-bldg_capacity_utilization.rename(
-    columns={
-        "Bldg ID": "Bldg_Code",
-        "Bldg Enroll": "Bldg_Enroll",
-        "Target Bldg Cap": "Bldg_Cap",
-        "Target Bldg Util": "Bldg_Util",
-        "Data As Of": "Util_As_Of",
-    },
-    inplace=True,
-)
-bldg_capacity_utilization["Util_As_Of"] = pd.to_datetime(
-    bldg_capacity_utilization["Util_As_Of"], format="%Y-%m-%d"
-)
-
-master_schools = master_schools.merge(
-    bldg_capacity_utilization[
-        ["Bldg_Code", "Bldg_Enroll", "Bldg_Cap", "Bldg_Util", "Util_As_Of"]
-    ],
-    on="Bldg_Code",
-    how="left",
-)
-
-# ---------------------------------------------------------------------------
-# Join BAP (Building Accessibility Profile)
-# ---------------------------------------------------------------------------
-# TODO: there's 1 single school with "No Information Available" for the description.
-# Remove that and make it null
-# TODO: fill nulls with "No Data" so that the Esri dashboard category filter can deal
-# with the nulls appropriately
-bap = pd.read_csv("data/processed_data/bap_with_school_codes.csv")
-bap.drop(columns=["Location Code"], inplace=True)
-bap.drop_duplicates(subset=["Building Code"], inplace=True)
-
-# TODO: undo all the 10-char column names and export as GPKG
-master_schools = master_schools.merge(
-    bap, left_on="Bldg_Code", right_on="Building Code", how="left"
-).drop(columns=["Building Code"])
-
-# ---------------------------------------------------------------------------
-# Join IBO School Barriers data
-# ---------------------------------------------------------------------------
-# NOTE: IBO only included schools that appeared in all their source datasets
-# (effectively an inner join). Going to primary sources may yield better coverage.
-# TODO: go back and get the original sources of all the data in IBO dataset to see if
-# we can get better coverage.
-ibo_barriers = pd.read_excel(
-    "data/raw_data/IBO/IBO-barriers-to-learning-data-file.xlsx", sheet_name="DATA"
-)
-print(
-    "Pct match from IBO to master_schools:",
-    ibo_barriers["building_code"].isin(master_schools["Bldg_Code"]).sum()
-    / len(ibo_barriers),
-)
-
-ibo_barriers["central_ac"] = ibo_barriers["central_ac"].map({"Y": 1, "N": 0})
-
-ibo_barriers = ibo_barriers[
-    ["building_code", "building_ownership_description", "yearbuilt", "age"]
-]
-
-master_schools = master_schools.merge(
-    ibo_barriers, left_on="Bldg_Code", right_on="building_code", how="left"
-).drop(columns=["building_code"])
-
-# ---------------------------------------------------------------------------
-# Join solar-readiness data
-# ---------------------------------------------------------------------------
-solar_readiness = pd.read_parquet(
-    "data/processed_data/solar_readiness_assessment_doe_buildings_2024.parquet"
-)
-solar_readiness.rename(
-    columns={
-        "Site": "Solar_Site",
-        "Status": "Solar_Status",
-        "Year of Report": "Solar_Year_of_Report",
-    },
-    inplace=True,
-)
-
-master_schools = master_schools.merge(
-    solar_readiness, left_on="Bldg_Code", right_on="Solar_Site", how="left"
-)
-
-# ---------------------------------------------------------------------------
-# Join city council districts
-# ---------------------------------------------------------------------------
-council_districts = gpd.read_file(
-    "data/processed_data/city_council_districts.geojson"
-).to_crs(master_schools.crs)
-master_schools = gpd.sjoin(
-    master_schools, council_districts, how="left", predicate="within"
-).drop(columns=["index_right", "BOROUGH", "Shape_Leng", "Shape_Area"])
-
-# ---------------------------------------------------------------------------
-# Join school districts
-# ---------------------------------------------------------------------------
-school_districts = gpd.read_file(
-    "data/raw_data/NYC Planning/School Districts/nysd_26a/nysd.shp"
-).to_crs(master_schools.crs)
-school_districts.drop(columns=["Shape_Leng", "Shape_Area"], inplace=True)
-
-master_schools = master_schools.sjoin(school_districts).drop(columns=["index_right"])
-
-# ---------------------------------------------------------------------------
-# Join LL84 energy data
-# ---------------------------------------------------------------------------
-ll84 = gpd.read_file("data/processed_data/ll84.geojson")
-master_schools = master_schools.merge(
-    ll84,
-    left_on=["Bldg_Code", "Loc_Code"],
-    right_on=["Building Code", "Location Code"],
-    how="left",
-    suffixes=("", "_right"),
-).drop(columns=["Location Code", "Building Code", "geometry_right"])
-
-# ---------------------------------------------------------------------------
-# Export
-# ---------------------------------------------------------------------------
-master_schools.fillna(value=pd.NA, inplace=True)
-
-shortened_cols = {
+SHORTENED_COLS = {
     # DAC columns
     "dac_designation": "in_dac",
     "combined_score": "comb_score",
@@ -312,25 +91,271 @@ shortened_cols = {
     "Other Sustainability Projects": "Sol_Ot_Prj",
 }
 
-for col in master_schools.rename(columns=shortened_cols).columns:
-    if len(col) > 10:
-        print(f"{col} too long: currently {len(col)} chars")
+# Columns produced internally that are not part of the ArcGIS schema.
+# Dropped before export.
+_INTERNAL_COLS = ["BoroName"]
 
-master_schools = master_schools.rename(columns=shortened_cols)
 
-shp_path = "data/processed_data/master_schools.shp"
-master_schools.sort_values("Loc_Code").to_file(shp_path, driver="ESRI Shapefile")
+# ---------------------------------------------------------------------------
+# Geometry fix
+# ---------------------------------------------------------------------------
 
-zip_path = "data/processed_data/master_schools.zip"
-base_name = "data/processed_data/master_schools"
-with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zipf:
-    for ext in [".shp", ".shx", ".dbf", ".prj", ".cpg"]:
-        file_path = base_name + ext
-        if os.path.exists(file_path):
-            zipf.write(file_path, os.path.basename(file_path))
-            print(f"Added {os.path.basename(file_path)} to zip")
-print(f"Shapefile saved as zip: {zip_path}")
 
-master_schools.sort_values("Loc_Code").to_file(
-    "data/processed_data/master_schools.geojson", driver="GeoJSON"
-)
+def snap_schools_by_building_code(schools: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    """Align schools that share a building to a shared centroid.
+
+    Multiple schools in the same building can have slightly different point
+    locations. Groups by Bldg_Code, replaces each group's geometries with the
+    centroid of the group, and updates lat/lng to match.
+    """
+    crs = schools.crs
+    centroid_by_bldg = (
+        schools.groupby("Bldg_Code")["geometry"]
+        .apply(lambda g: g.union_all().centroid)
+        .rename("snapped_geom")
+    )
+    result = schools.join(centroid_by_bldg, on="Bldg_Code")
+    result["lat"] = result["snapped_geom"].y
+    result["lng"] = result["snapped_geom"].x
+    return (
+        result.set_geometry("snapped_geom", crs=crs)
+        .drop(columns=["geometry"])
+        .rename_geometry("geometry")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Join functions
+# ---------------------------------------------------------------------------
+
+
+def join_boroughs(schools: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    boroughs = gpd.read_file("data/raw_data/NYC Planning/Boroughs/nybb_25c/nybb.shp")[
+        ["BoroName", "geometry"]
+    ].to_crs(schools.crs)
+    return gpd.sjoin(schools, boroughs, how="left", predicate="within").drop(
+        columns=["index_right"]
+    )
+
+
+def join_dacs(schools: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    dacs = gpd.read_file("data/processed_data/dac_nyc_lite.geojson")
+    dac_union = dacs.union_all()
+    assert (
+        schools.geometry.apply(dac_union.covers).sum()
+        == schools.geometry.within(dac_union).sum()
+    ), "Some schools sit exactly on a DAC border — check geometry validity"
+    result = gpd.sjoin(schools, dacs, how="left", predicate="within").drop(
+        columns=["index_right", "county", "geoid"]
+    )
+    result["dac_designation"] = result["dac_designation"].fillna(False)
+    return result
+
+
+def join_election_results(schools: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    primary_results = gpd.read_file(
+        "data/processed_data/zohran_first_round_frac.geojson"
+    )
+    og_crs = schools.crs
+    schools_proj = schools.to_crs("EPSG:3857")
+    results_proj = primary_results.to_crs("EPSG:3857")
+
+    joined = gpd.sjoin(schools_proj, results_proj, how="left", predicate="within").drop(
+        columns=["index_right"]
+    )
+
+    unmatched = joined["ZohranFirstRoundFrac"].isna()
+    print(
+        f"Found {unmatched.sum()} schools without polygon matches, "
+        "using nearest neighbor..."
+    )
+    nearest = gpd.tools.sjoin_nearest(
+        joined[unmatched].drop(columns="ZohranFirstRoundFrac"),
+        results_proj,
+        how="left",
+    )
+    joined.loc[unmatched, "ZohranFirstRoundFrac"] = nearest[
+        "ZohranFirstRoundFrac"
+    ].values
+
+    assert not joined["ZohranFirstRoundFrac"].isna().any()
+    return joined.to_crs(og_crs)
+
+
+def join_ac(schools: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    no_ac = pd.read_csv("data/processed_data/no_ac_summary.csv")
+    ct_missing = schools["Bldg_Code"].nunique() - no_ac["BuildingCode"].nunique()
+    result = schools.merge(
+        no_ac, left_on="Bldg_Code", right_on="BuildingCode", how="left"
+    ).drop(columns=["BuildingCode"])
+    assert (
+        result.drop_duplicates(subset=["Bldg_Code"])["CLS_No_AC"].isna().sum()
+        == ct_missing
+    )
+    return result
+
+
+def join_ventilation(schools: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    vent = pd.read_csv("data/processed_data/missing_ventilation_summary.csv")
+    ct_missing = schools["Bldg_Code"].nunique() - vent["BuildingCode"].nunique()
+    result = schools.merge(
+        vent, left_on="Bldg_Code", right_on="BuildingCode", how="left"
+    ).drop(columns=["BuildingCode"])
+    assert (
+        result.drop_duplicates(subset=["Bldg_Code"])["CLS_No_VT"].isna().sum()
+        == ct_missing
+    )
+    return result
+
+
+def join_capacity_utilization(schools: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    cap = pd.read_csv("data/processed_data/bldg_capacity_utilization.csv")
+    cap.rename(
+        columns={
+            "Bldg ID": "Bldg_Code",
+            "Bldg Enroll": "Bldg_Enroll",
+            "Target Bldg Cap": "Bldg_Cap",
+            "Target Bldg Util": "Bldg_Util",
+            "Data As Of": "Util_As_Of",
+        },
+        inplace=True,
+    )
+    cap["Util_As_Of"] = pd.to_datetime(cap["Util_As_Of"], format="%Y-%m-%d")
+    return schools.merge(
+        cap[["Bldg_Code", "Bldg_Enroll", "Bldg_Cap", "Bldg_Util", "Util_As_Of"]],
+        on="Bldg_Code",
+        how="left",
+    )
+
+
+def join_bap(schools: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    # TODO: 1 school has "No Information Available" — remove and make null
+    # TODO: fill nulls with "No Data" for Esri dashboard category filter
+    bap = pd.read_csv("data/processed_data/bap_with_school_codes.csv")
+    bap.drop(columns=["Location Code"], inplace=True)
+    bap.drop_duplicates(subset=["Building Code"], inplace=True)
+    return schools.merge(
+        bap, left_on="Bldg_Code", right_on="Building Code", how="left"
+    ).drop(columns=["Building Code"])
+
+
+def join_ibo(schools: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    # NOTE: IBO only included schools appearing in all their source datasets
+    # (effectively an inner join). Going to primary sources may yield better coverage.
+    # TODO: go back and get the original sources of all the data in IBO dataset
+    ibo = pd.read_excel(
+        "data/raw_data/IBO/IBO-barriers-to-learning-data-file.xlsx", sheet_name="DATA"
+    )
+    print(
+        "Pct match from IBO to master_schools:",
+        ibo["building_code"].isin(schools["Bldg_Code"]).sum() / len(ibo),
+    )
+    ibo["central_ac"] = ibo["central_ac"].map({"Y": 1, "N": 0})
+    ibo = ibo[["building_code", "building_ownership_description", "yearbuilt", "age"]]
+    return schools.merge(
+        ibo, left_on="Bldg_Code", right_on="building_code", how="left"
+    ).drop(columns=["building_code"])
+
+
+def join_solar(schools: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    solar = pd.read_parquet(
+        "data/processed_data/solar_readiness_assessment_doe_buildings_2024.parquet"
+    )
+    solar.rename(
+        columns={
+            "Site": "Solar_Site",
+            "Status": "Solar_Status",
+            "Year of Report": "Solar_Year_of_Report",
+        },
+        inplace=True,
+    )
+    return schools.merge(solar, left_on="Bldg_Code", right_on="Solar_Site", how="left")
+
+
+def join_council_districts(schools: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    council = gpd.read_file(
+        "data/processed_data/city_council_districts.geojson"
+    ).to_crs(schools.crs)
+    return gpd.sjoin(schools, council, how="left", predicate="within").drop(
+        columns=["index_right", "BOROUGH", "Shape_Leng", "Shape_Area"]
+    )
+
+
+def join_school_districts(schools: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    districts = gpd.read_file(
+        "data/raw_data/NYC Planning/School Districts/nysd_26a/nysd.shp"
+    ).to_crs(schools.crs)
+    districts.drop(columns=["Shape_Leng", "Shape_Area"], inplace=True)
+    return schools.sjoin(districts).drop(columns=["index_right"])
+
+
+def join_ll84(schools: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    ll84 = gpd.read_file("data/processed_data/ll84.geojson")
+    return schools.merge(
+        ll84,
+        left_on=["Bldg_Code", "Loc_Code"],
+        right_on=["Building Code", "Location Code"],
+        how="left",
+        suffixes=("", "_right"),
+    ).drop(columns=["Location Code", "Building Code", "geometry_right"])
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+def build_master_schools(
+    schools_path: str = "data/processed_data/school_points_with_lcgms.shp",
+) -> gpd.GeoDataFrame:
+    schools = gpd.read_file(schools_path)
+    schools = snap_schools_by_building_code(schools)
+    master = join_boroughs(schools)
+    master = join_dacs(master)
+    master = join_election_results(master)
+    master = join_ac(master)
+    master = join_ventilation(master)
+    master = join_capacity_utilization(master)
+    master = join_bap(master)
+    master = join_ibo(master)
+    master = join_solar(master)
+    master = join_council_districts(master)
+    master = join_school_districts(master)
+    master = join_ll84(master)
+
+    master = master.fillna(value=pd.NA)
+    master = master.drop(columns=[c for c in _INTERNAL_COLS if c in master.columns])
+    master = master.rename(columns=SHORTENED_COLS)
+
+    for col in master.columns:
+        if len(col) > 10:
+            print(f"WARNING: column name too long for shapefile export: {col!r}")
+
+    return master
+
+
+def export(master: gpd.GeoDataFrame) -> None:
+    master = master.sort_values("Loc_Code")
+
+    shp_path = "data/processed_data/master_schools.shp"
+    master.to_file(shp_path, driver="ESRI Shapefile")
+
+    zip_path = "data/processed_data/master_schools.zip"
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for ext in [".shp", ".shx", ".dbf", ".prj", ".cpg"]:
+            fp = "data/processed_data/master_schools" + ext
+            if os.path.exists(fp):
+                zf.write(fp, os.path.basename(fp))
+                print(f"Added {os.path.basename(fp)} to zip")
+    print(f"Shapefile saved as zip: {zip_path}")
+
+    master.to_file("data/processed_data/master_schools.geojson", driver="GeoJSON")
+
+
+def main() -> None:
+    master = build_master_schools()
+    export(master)
+
+
+if __name__ == "__main__":
+    main()

--- a/pipelines/join_to_schools.py
+++ b/pipelines/join_to_schools.py
@@ -1,0 +1,336 @@
+import os
+import zipfile
+
+import geopandas as gpd
+import pandas as pd
+
+# ---------------------------------------------------------------------------
+# Load school points
+# ---------------------------------------------------------------------------
+schools = gpd.read_file("data/processed_data/school_points_with_lcgms.shp")
+
+# ---------------------------------------------------------------------------
+# Join boroughs
+# ---------------------------------------------------------------------------
+boroughs = gpd.read_file("data/raw_data/NYC Planning/Boroughs/nybb_25c/nybb.shp")[
+    ["BoroName", "geometry"]
+].to_crs(schools.crs)
+master_schools = gpd.sjoin(schools, boroughs, how="left", predicate="within").drop(
+    columns=["index_right"]
+)
+
+# ---------------------------------------------------------------------------
+# Join DACs
+# ---------------------------------------------------------------------------
+dacs = gpd.read_file("data/processed_data/dac_nyc_lite.geojson")
+
+# Check that no schools sit exactly on a DAC border
+assert (
+    schools.geometry.apply(dacs.union_all().covers).sum()
+    == schools.geometry.within(dacs.union_all()).sum()
+)
+
+master_schools = gpd.sjoin(schools, dacs, how="left", predicate="within")
+master_schools.drop(columns=["index_right", "county", "geoid"], inplace=True)
+master_schools["dac_designation"] = master_schools["dac_designation"].fillna(False)
+
+# ---------------------------------------------------------------------------
+# Join election results (nearest-neighbor fallback for unmatched schools)
+# ---------------------------------------------------------------------------
+primary_results = gpd.read_file("data/processed_data/zohran_first_round_frac.geojson")
+
+master_schools_og_crs = master_schools.crs
+primary_results_og_crs = primary_results.crs
+master_schools = master_schools.to_crs("EPSG:3857")
+primary_results = primary_results.to_crs("EPSG:3857")
+
+master_schools = gpd.sjoin(
+    master_schools, primary_results, how="left", predicate="within"
+).drop(columns=["index_right"])
+
+unmatched_mask = master_schools["ZohranFirstRoundFrac"].isna()
+unmatched_schools = master_schools[unmatched_mask].copy()
+print(
+    f"Found {unmatched_mask.sum()} schools without polygon matches, "
+    "using nearest neighbor..."
+)
+
+nearest_join = gpd.tools.sjoin_nearest(
+    unmatched_schools.drop(columns="ZohranFirstRoundFrac"), primary_results, how="left"
+)
+master_schools.loc[unmatched_mask, "ZohranFirstRoundFrac"] = nearest_join[
+    "ZohranFirstRoundFrac"
+].values
+
+assert not master_schools["ZohranFirstRoundFrac"].isna().any()
+
+master_schools = master_schools.to_crs(master_schools_og_crs)
+primary_results = primary_results.to_crs(primary_results_og_crs)
+
+# ---------------------------------------------------------------------------
+# Join A/C data
+# ---------------------------------------------------------------------------
+no_ac_summary = pd.read_csv("data/processed_data/no_ac_summary.csv")
+
+ct_bldg_codes_missing_from_ac_data = (
+    master_schools["Bldg_Code"].nunique() - no_ac_summary["BuildingCode"].nunique()
+)
+
+master_schools = master_schools.merge(
+    no_ac_summary, left_on="Bldg_Code", right_on="BuildingCode", how="left"
+).drop(columns=["BuildingCode"])
+
+assert (
+    master_schools.drop_duplicates(subset=["Bldg_Code"])["CLS_No_AC"].isna().sum()
+    == ct_bldg_codes_missing_from_ac_data
+)
+
+# ---------------------------------------------------------------------------
+# Join ventilation data
+# ---------------------------------------------------------------------------
+missing_ventilation_summary = pd.read_csv(
+    "data/processed_data/missing_ventilation_summary.csv"
+)
+
+ct_bldg_codes_missing_from_vent_data = (
+    master_schools["Bldg_Code"].nunique()
+    - missing_ventilation_summary["BuildingCode"].nunique()
+)
+
+master_schools = master_schools.merge(
+    missing_ventilation_summary,
+    left_on="Bldg_Code",
+    right_on="BuildingCode",
+    how="left",
+).drop(columns=["BuildingCode"])
+
+assert (
+    master_schools.drop_duplicates(subset=["Bldg_Code"])["CLS_No_VT"].isna().sum()
+    == ct_bldg_codes_missing_from_vent_data
+)
+
+# ---------------------------------------------------------------------------
+# Join building capacity + utilization
+# ---------------------------------------------------------------------------
+bldg_capacity_utilization = pd.read_csv(
+    "data/processed_data/bldg_capacity_utilization.csv"
+)
+bldg_capacity_utilization.rename(
+    columns={
+        "Bldg ID": "Bldg_Code",
+        "Bldg Enroll": "Bldg_Enroll",
+        "Target Bldg Cap": "Bldg_Cap",
+        "Target Bldg Util": "Bldg_Util",
+        "Data As Of": "Util_As_Of",
+    },
+    inplace=True,
+)
+bldg_capacity_utilization["Util_As_Of"] = pd.to_datetime(
+    bldg_capacity_utilization["Util_As_Of"], format="%Y-%m-%d"
+)
+
+master_schools = master_schools.merge(
+    bldg_capacity_utilization[
+        ["Bldg_Code", "Bldg_Enroll", "Bldg_Cap", "Bldg_Util", "Util_As_Of"]
+    ],
+    on="Bldg_Code",
+    how="left",
+)
+
+# ---------------------------------------------------------------------------
+# Join BAP (Building Accessibility Profile)
+# ---------------------------------------------------------------------------
+# TODO: there's 1 single school with "No Information Available" for the description.
+# Remove that and make it null
+# TODO: fill nulls with "No Data" so that the Esri dashboard category filter can deal
+# with the nulls appropriately
+bap = pd.read_csv("data/processed_data/bap_with_school_codes.csv")
+bap.drop(columns=["Location Code"], inplace=True)
+bap.drop_duplicates(subset=["Building Code"], inplace=True)
+
+# TODO: undo all the 10-char column names and export as GPKG
+master_schools = master_schools.merge(
+    bap, left_on="Bldg_Code", right_on="Building Code", how="left"
+).drop(columns=["Building Code"])
+
+# ---------------------------------------------------------------------------
+# Join IBO School Barriers data
+# ---------------------------------------------------------------------------
+# NOTE: IBO only included schools that appeared in all their source datasets
+# (effectively an inner join). Going to primary sources may yield better coverage.
+# TODO: go back and get the original sources of all the data in IBO dataset to see if
+# we can get better coverage.
+ibo_barriers = pd.read_excel(
+    "data/raw_data/IBO/IBO-barriers-to-learning-data-file.xlsx", sheet_name="DATA"
+)
+print(
+    "Pct match from IBO to master_schools:",
+    ibo_barriers["building_code"].isin(master_schools["Bldg_Code"]).sum()
+    / len(ibo_barriers),
+)
+
+ibo_barriers["central_ac"] = ibo_barriers["central_ac"].map({"Y": 1, "N": 0})
+
+ibo_barriers = ibo_barriers[
+    ["building_code", "building_ownership_description", "yearbuilt", "age"]
+]
+
+master_schools = master_schools.merge(
+    ibo_barriers, left_on="Bldg_Code", right_on="building_code", how="left"
+).drop(columns=["building_code"])
+
+# ---------------------------------------------------------------------------
+# Join solar-readiness data
+# ---------------------------------------------------------------------------
+solar_readiness = pd.read_parquet(
+    "data/processed_data/solar_readiness_assessment_doe_buildings_2024.parquet"
+)
+solar_readiness.rename(
+    columns={
+        "Site": "Solar_Site",
+        "Status": "Solar_Status",
+        "Year of Report": "Solar_Year_of_Report",
+    },
+    inplace=True,
+)
+
+master_schools = master_schools.merge(
+    solar_readiness, left_on="Bldg_Code", right_on="Solar_Site", how="left"
+)
+
+# ---------------------------------------------------------------------------
+# Join city council districts
+# ---------------------------------------------------------------------------
+council_districts = gpd.read_file(
+    "data/processed_data/city_council_districts.geojson"
+).to_crs(master_schools.crs)
+master_schools = gpd.sjoin(
+    master_schools, council_districts, how="left", predicate="within"
+).drop(columns=["index_right", "BOROUGH", "Shape_Leng", "Shape_Area"])
+
+# ---------------------------------------------------------------------------
+# Join school districts
+# ---------------------------------------------------------------------------
+school_districts = gpd.read_file(
+    "data/raw_data/NYC Planning/School Districts/nysd_26a/nysd.shp"
+).to_crs(master_schools.crs)
+school_districts.drop(columns=["Shape_Leng", "Shape_Area"], inplace=True)
+
+master_schools = master_schools.sjoin(school_districts).drop(columns=["index_right"])
+
+# ---------------------------------------------------------------------------
+# Join LL84 energy data
+# ---------------------------------------------------------------------------
+ll84 = gpd.read_file("data/processed_data/ll84.geojson")
+master_schools = master_schools.merge(
+    ll84,
+    left_on=["Bldg_Code", "Loc_Code"],
+    right_on=["Building Code", "Location Code"],
+    how="left",
+    suffixes=("", "_right"),
+).drop(columns=["Location Code", "Building Code", "geometry_right"])
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+master_schools.fillna(value=pd.NA, inplace=True)
+
+shortened_cols = {
+    # DAC columns
+    "dac_designation": "in_dac",
+    "combined_score": "comb_score",
+    "percentile_rank_combined_nyc": "pctl_comb",
+    "burden_score": "burd_score",
+    "burden_score_percentile": "pctl_burd",
+    "vulnerability_score": "vuln_score",
+    "vulnerability_score_percentile": "pctl_vuln",
+    # Primary results columns
+    "ZohranFirstRoundFrac": "ZohrPrimR1",
+    # Building Accessibility Profile columns
+    "BAP Rating": "BAP_Rating",
+    "Accessibility Description": "AccessDesc",
+    # IBO columns
+    "age": "Bldg_Age",
+    "building_ownership_description": "Bldg_Owner",
+    "Accessibility_Description": "Accessible",
+    # Council District columns
+    "NAME": "CouncName",
+    "POLITICAL PARTY": "CouncParty",
+    "DISTRICT OFFICE ADDRESS": "CouncAddr",
+    "DISTRICT OFFICE PHONE": "CouncPhone",
+    # LL84 columns
+    "ENERGY STAR Score": "eng_star",
+    "Site EUI (kBtu/ft²)": "eui_norm",
+    "Site Energy Use (kBtu)": "eui_raw",
+    "Percent Electricity": "pct_elec",
+    "Direct GHG Emissions (Metric Tons CO2e)": "ghg_raw",
+    "Direct GHG Emissions Intensity (kgCO2e/ft²)": "ghg_norm",
+    "Water Use (All Water Sources) (kgal)": "water_use",
+    "Weather Normalized Site EUI (kBtu/ft²)": "WN_SiteEUI",
+    "Weather Normalized Site Energy Use (kBtu)": "WN_SiteEn",
+    "Fuel Oil #1 Use (kBtu)": "FO1_kBtu",
+    "Fuel Oil #2 Use (kBtu)": "FO2_kBtu",
+    "Fuel Oil #4 Use (kBtu)": "FO4_kBtu",
+    "Fuel Oil #5 & 6 Use (kBtu)": "FO56_kBtu",
+    "Diesel #2 Use (kBtu)": "Diesel2",
+    "Propane Use (kBtu)": "Propane",
+    "Kerosene Use (kBtu)": "Kerosene",
+    "District Steam Use (kBtu)": "DistSteam",
+    "District Hot Water Use (kBtu)": "DistHotW",
+    "District Chilled Water Use (kBtu)": "DistChill",
+    "Natural Gas Use (kBtu)": "NatGas",
+    "Electricity Use - Grid Purchase (kBtu)": "Elec_kBtu",
+    "Electricity Use - Grid Purchase (kWh)": "Elec_kWh",
+    "Electricity Use – Generated from Onsite Renewable Systems (kWh)": "OnsiteGen",
+    "Electricity Use – Generated from Onsite Renewable Systems and Exported (kWh)": (
+        "OnGenExp"
+    ),
+    "Green Power - Onsite (kWh)": "GreenPwr",
+    "Avoided Emissions - Onsite Green Power (Metric Tons CO2e)": "AvoidCO2",
+    "Percent of Electricity that is Green Power": "PctGreen",
+    "Percent of Total Electricity Generated from Onsite Renewable Systems": "PctOnGen",
+    "Report Submission Date": "RptDate",
+    # Capacity Utilization columns
+    "Bldg_Enroll": "Bldg_Enrl",
+    # Solar-Readiness columns
+    "Solar_Status": "Sol_Stat",
+    "Solar_Year_of_Report": "Sol_Yr_Rep",
+    "Capacity (kW)": "Sol_Capac",
+    "Solar-Readiness Assessment": "Sol_Rd_Ass",
+    "Percentage of Max Peak Demand": "SolPctDemd",
+    "Estimated Annual Production (kWh)": "SolEstProd",
+    "Percentage of Annual Electricity Consumption": "SolPctCnsm",
+    "Estimated Annual Emissions Reduction (MT CO2)": "SolEmisRed",
+    "Estimated Social Cost of Carbon Value": "SolSocCost",
+    "Estimated Annual Energy Savings": "SolEnrgSav",
+    "Installation Date": "SolInstDt",
+    "Financing Mechanism": "SolFinMech",
+    "Upfront Project Cost": "Sol_Cost",
+    "Total Gross Square Footage": "SolTotSqFt",
+    "Roof Condition": "Sol_Rf_Con",
+    "Roof Age": "Sol_Rf_Age",
+    "Other Sustainability Projects": "Sol_Ot_Prj",
+}
+
+for col in master_schools.rename(columns=shortened_cols).columns:
+    if len(col) > 10:
+        print(f"{col} too long: currently {len(col)} chars")
+
+master_schools = master_schools.rename(columns=shortened_cols)
+
+shp_path = "data/processed_data/master_schools.shp"
+master_schools.sort_values("Loc_Code").to_file(shp_path, driver="ESRI Shapefile")
+
+zip_path = "data/processed_data/master_schools.zip"
+base_name = "data/processed_data/master_schools"
+with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zipf:
+    for ext in [".shp", ".shx", ".dbf", ".prj", ".cpg"]:
+        file_path = base_name + ext
+        if os.path.exists(file_path):
+            zipf.write(file_path, os.path.basename(file_path))
+            print(f"Added {os.path.basename(file_path)} to zip")
+print(f"Shapefile saved as zip: {zip_path}")
+
+master_schools.sort_values("Loc_Code").to_file(
+    "data/processed_data/master_schools.geojson", driver="GeoJSON"
+)

--- a/pipelines/join_to_schools.py
+++ b/pipelines/join_to_schools.py
@@ -97,6 +97,44 @@ _INTERNAL_COLS = ["BoroName"]
 
 
 # ---------------------------------------------------------------------------
+# DQ assertion helper
+# ---------------------------------------------------------------------------
+
+
+def check_join(
+    before: gpd.GeoDataFrame,
+    after: gpd.GeoDataFrame,
+    join_name: str,
+    *,
+    null_sentinel_cols: list[str],
+    match_col: str | None = None,
+    min_match_rate: float | None = None,
+) -> None:
+    """Assert join quality invariants; raise AssertionError on failure."""
+    assert len(after) == len(
+        before
+    ), f"{join_name}: row count changed {len(before)} → {len(after)}"
+    for col in null_sentinel_cols:
+        before_nulls = int(before[col].isna().sum())
+        after_nulls = int(after[col].isna().sum())
+        assert after_nulls <= before_nulls, (
+            f"{join_name}: null count increased in {col!r}: "
+            f"{before_nulls} → {after_nulls}"
+        )
+    if "Loc_Code" in after.columns:
+        dupes = int(after["Loc_Code"].duplicated().sum())
+        assert dupes == 0, f"{join_name}: {dupes} duplicate Loc_Code values after join"
+    if match_col is not None:
+        rate = after[match_col].notna().mean()
+        print(f"{join_name}: match rate on {match_col!r} = {rate:.1%}")
+        if min_match_rate is not None:
+            assert rate >= min_match_rate, (
+                f"{join_name}: match rate {rate:.1%} below threshold "
+                f"{min_match_rate:.1%} on {match_col!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
 # Geometry fix
 # ---------------------------------------------------------------------------
 
@@ -133,9 +171,19 @@ def join_boroughs(schools: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
     boroughs = gpd.read_file("data/raw_data/NYC Planning/Boroughs/nybb_25c/nybb.shp")[
         ["BoroName", "geometry"]
     ].to_crs(schools.crs)
-    return gpd.sjoin(schools, boroughs, how="left", predicate="within").drop(
+    result = gpd.sjoin(schools, boroughs, how="left", predicate="within").drop(
         columns=["index_right"]
     )
+    check_join(
+        schools,
+        result,
+        "boroughs",
+        null_sentinel_cols=["Loc_Code", "Bldg_Code"],
+        match_col="BoroName",
+        # 0.99 — every NYC school should fall within a borough polygon
+        min_match_rate=0.99,
+    )
+    return result
 
 
 def join_dacs(schools: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
@@ -149,6 +197,13 @@ def join_dacs(schools: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
         columns=["index_right", "county", "geoid"]
     )
     result["dac_designation"] = result["dac_designation"].fillna(False)
+    check_join(
+        schools,
+        result,
+        "DACs",
+        null_sentinel_cols=["Loc_Code", "Bldg_Code"],
+        # dac_designation filled False for non-DAC schools; no match threshold needed
+    )
     return result
 
 
@@ -178,32 +233,49 @@ def join_election_results(schools: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
         "ZohranFirstRoundFrac"
     ].values
 
-    assert not joined["ZohranFirstRoundFrac"].isna().any()
-    return joined.to_crs(og_crs)
+    result = joined.to_crs(og_crs)
+    check_join(
+        schools,
+        result,
+        "election results",
+        null_sentinel_cols=["Loc_Code", "Bldg_Code"],
+        match_col="ZohranFirstRoundFrac",
+        # 1.0 — nearest neighbor fallback ensures every school gets a result
+        min_match_rate=1.0,
+    )
+    return result
 
 
 def join_ac(schools: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
     no_ac = pd.read_csv("data/processed_data/no_ac_summary.csv")
-    ct_missing = schools["Bldg_Code"].nunique() - no_ac["BuildingCode"].nunique()
     result = schools.merge(
         no_ac, left_on="Bldg_Code", right_on="BuildingCode", how="left"
     ).drop(columns=["BuildingCode"])
-    assert (
-        result.drop_duplicates(subset=["Bldg_Code"])["CLS_No_AC"].isna().sum()
-        == ct_missing
+    check_join(
+        schools,
+        result,
+        "A/C",
+        null_sentinel_cols=["Loc_Code", "Bldg_Code"],
+        match_col="CLS_No_AC",
+        # 0.85 — scraped from nycenet.edu; not all buildings appear (actual ~89%)
+        min_match_rate=0.85,
     )
     return result
 
 
 def join_ventilation(schools: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
     vent = pd.read_csv("data/processed_data/missing_ventilation_summary.csv")
-    ct_missing = schools["Bldg_Code"].nunique() - vent["BuildingCode"].nunique()
     result = schools.merge(
         vent, left_on="Bldg_Code", right_on="BuildingCode", how="left"
     ).drop(columns=["BuildingCode"])
-    assert (
-        result.drop_duplicates(subset=["Bldg_Code"])["CLS_No_VT"].isna().sum()
-        == ct_missing
+    check_join(
+        schools,
+        result,
+        "ventilation",
+        null_sentinel_cols=["Loc_Code", "Bldg_Code"],
+        match_col="CLS_No_VT",
+        # 0.85 — scraped from nycenet.edu; not all buildings appear (actual ~89%)
+        min_match_rate=0.85,
     )
     return result
 
@@ -221,11 +293,21 @@ def join_capacity_utilization(schools: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
         inplace=True,
     )
     cap["Util_As_Of"] = pd.to_datetime(cap["Util_As_Of"], format="%Y-%m-%d")
-    return schools.merge(
+    result = schools.merge(
         cap[["Bldg_Code", "Bldg_Enroll", "Bldg_Cap", "Bldg_Util", "Util_As_Of"]],
         on="Bldg_Code",
         how="left",
     )
+    check_join(
+        schools,
+        result,
+        "capacity utilization",
+        null_sentinel_cols=["Loc_Code", "Bldg_Code"],
+        match_col="Bldg_Cap",
+        # 0.80 — SCA data doesn't cover all buildings (leased, charters); actual ~87%
+        min_match_rate=0.80,
+    )
+    return result
 
 
 def join_bap(schools: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
@@ -234,9 +316,19 @@ def join_bap(schools: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
     bap = pd.read_csv("data/processed_data/bap_with_school_codes.csv")
     bap.drop(columns=["Location Code"], inplace=True)
     bap.drop_duplicates(subset=["Building Code"], inplace=True)
-    return schools.merge(
+    result = schools.merge(
         bap, left_on="Bldg_Code", right_on="Building Code", how="left"
     ).drop(columns=["Building Code"])
+    check_join(
+        schools,
+        result,
+        "BAP",
+        null_sentinel_cols=["Loc_Code", "Bldg_Code"],
+        match_col="BAP Rating",
+        # 0.95 — full coverage expected (actual 100%); floor catches data loss
+        min_match_rate=0.95,
+    )
+    return result
 
 
 def join_ibo(schools: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
@@ -252,9 +344,19 @@ def join_ibo(schools: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
     )
     ibo["central_ac"] = ibo["central_ac"].map({"Y": 1, "N": 0})
     ibo = ibo[["building_code", "building_ownership_description", "yearbuilt", "age"]]
-    return schools.merge(
+    result = schools.merge(
         ibo, left_on="Bldg_Code", right_on="building_code", how="left"
     ).drop(columns=["building_code"])
+    check_join(
+        schools,
+        result,
+        "IBO",
+        null_sentinel_cols=["Loc_Code", "Bldg_Code"],
+        match_col="age",
+        # 0.80 — IBO is an inner join of multiple source datasets; actual ~86%
+        min_match_rate=0.80,
+    )
+    return result
 
 
 def join_solar(schools: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
@@ -269,16 +371,38 @@ def join_solar(schools: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
         },
         inplace=True,
     )
-    return schools.merge(solar, left_on="Bldg_Code", right_on="Solar_Site", how="left")
+    result = schools.merge(
+        solar, left_on="Bldg_Code", right_on="Solar_Site", how="left"
+    )
+    check_join(
+        schools,
+        result,
+        "solar",
+        null_sentinel_cols=["Loc_Code", "Bldg_Code"],
+        match_col="Solar_Status",
+        # 0.80 — hand-extracted from LL24 PDF; not all buildings in report (actual ~86%)
+        min_match_rate=0.80,
+    )
+    return result
 
 
 def join_council_districts(schools: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
     council = gpd.read_file(
         "data/processed_data/city_council_districts.geojson"
     ).to_crs(schools.crs)
-    return gpd.sjoin(schools, council, how="left", predicate="within").drop(
+    result = gpd.sjoin(schools, council, how="left", predicate="within").drop(
         columns=["index_right", "BOROUGH", "Shape_Leng", "Shape_Area"]
     )
+    check_join(
+        schools,
+        result,
+        "council districts",
+        null_sentinel_cols=["Loc_Code", "Bldg_Code"],
+        match_col="NAME",
+        # 0.99 — spatial join; 100% actual coverage; floor catches CRS or data issues
+        min_match_rate=0.99,
+    )
+    return result
 
 
 def join_school_districts(schools: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
@@ -286,18 +410,38 @@ def join_school_districts(schools: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
         "data/raw_data/NYC Planning/School Districts/nysd_26a/nysd.shp"
     ).to_crs(schools.crs)
     districts.drop(columns=["Shape_Leng", "Shape_Area"], inplace=True)
-    return schools.sjoin(districts).drop(columns=["index_right"])
+    result = schools.sjoin(districts, how="left").drop(columns=["index_right"])
+    check_join(
+        schools,
+        result,
+        "school districts",
+        null_sentinel_cols=["Loc_Code", "Bldg_Code"],
+        match_col="SchoolDist",
+        # 0.99 — every school should fall within a school district polygon
+        min_match_rate=0.99,
+    )
+    return result
 
 
 def join_ll84(schools: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
     ll84 = gpd.read_file("data/processed_data/ll84.geojson")
-    return schools.merge(
+    result = schools.merge(
         ll84,
         left_on=["Bldg_Code", "Loc_Code"],
         right_on=["Building Code", "Location Code"],
         how="left",
         suffixes=("", "_right"),
     ).drop(columns=["Location Code", "Building Code", "geometry_right"])
+    check_join(
+        schools,
+        result,
+        "LL84",
+        null_sentinel_cols=["Loc_Code", "Bldg_Code"],
+        match_col="ENERGY STAR Score",
+        # 0.85 — not all buildings qualify for Energy Star Score (actual ~91%)
+        min_match_rate=0.85,
+    )
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pipeline_dq.py
+++ b/tests/test_pipeline_dq.py
@@ -1,0 +1,83 @@
+"""Tests for the check_join DQ assertion helper."""
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import Point
+
+from pipelines.join_to_schools import check_join
+
+
+def _gdf(loc_codes, bldg_codes, **extra):
+    """Build a minimal GeoDataFrame for DQ tests."""
+    n = len(loc_codes)
+    data = {
+        "Loc_Code": loc_codes,
+        "Bldg_Code": bldg_codes,
+        "geometry": [Point(0, i) for i in range(n)],
+        **extra,
+    }
+    return gpd.GeoDataFrame(data, crs="EPSG:4326")
+
+
+class TestCheckJoin:
+    def test_passes_silently_when_all_conditions_met(self):
+        before = _gdf(["A", "B"], ["X", "Y"])
+        after = _gdf(["A", "B"], ["X", "Y"], score=[1.0, 2.0])
+        check_join(
+            before,
+            after,
+            "test",
+            null_sentinel_cols=["Loc_Code", "Bldg_Code"],
+            match_col="score",
+            min_match_rate=1.0,
+        )
+
+    def test_raises_when_row_count_increases(self):
+        before = _gdf(["A", "B"], ["X", "Y"])
+        after = _gdf(["A", "B", "C"], ["X", "Y", "Z"])
+        with pytest.raises(AssertionError, match="row count"):
+            check_join(before, after, "test", null_sentinel_cols=["Loc_Code"])
+
+    def test_raises_when_sentinel_col_gains_nulls(self):
+        before = _gdf(["A", "B"], ["X", "Y"])
+        after = _gdf([None, "B"], ["X", "Y"])
+        with pytest.raises(AssertionError, match="null count increased"):
+            check_join(before, after, "test", null_sentinel_cols=["Loc_Code"])
+
+    def test_raises_when_duplicate_loc_codes(self):
+        before = _gdf(["A", "B"], ["X", "Y"])
+        after = _gdf(["A", "A"], ["X", "X"])
+        with pytest.raises(AssertionError, match="duplicate Loc_Code"):
+            check_join(before, after, "test", null_sentinel_cols=["Bldg_Code"])
+
+    def test_raises_when_match_rate_below_threshold_with_actual_rate_in_message(self):
+        before = _gdf(["A", "B", "C", "D"], ["W", "X", "Y", "Z"])
+        after = _gdf(
+            ["A", "B", "C", "D"],
+            ["W", "X", "Y", "Z"],
+            score=[1.0, None, None, None],
+        )
+        with pytest.raises(AssertionError, match="25.0%"):
+            check_join(
+                before,
+                after,
+                "test",
+                null_sentinel_cols=["Loc_Code"],
+                match_col="score",
+                min_match_rate=0.80,
+            )
+
+    def test_logs_match_rate_to_stdout_even_when_above_threshold(self, capsys):
+        before = _gdf(["A", "B"], ["X", "Y"])
+        after = _gdf(["A", "B"], ["X", "Y"], score=[1.0, 2.0])
+        check_join(
+            before,
+            after,
+            "test",
+            null_sentinel_cols=["Loc_Code"],
+            match_col="score",
+            min_match_rate=0.80,
+        )
+        captured = capsys.readouterr()
+        assert "score" in captured.out
+        assert "100.0%" in captured.out

--- a/tests/test_snap_points.py
+++ b/tests/test_snap_points.py
@@ -1,0 +1,57 @@
+"""
+TDD tests for snap_schools_by_building_code.
+
+Verified 2026-06-06 against ArcGIS export: snapped coords match André's
+implementation within 20m for all 309 fully-aligned multi-school buildings.
+"""
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import Point
+
+from pipelines.join_to_schools import snap_schools_by_building_code
+
+
+@pytest.fixture
+def schools() -> gpd.GeoDataFrame:
+    """Minimal synthetic dataset: two multi-school buildings and one solo school."""
+    return gpd.GeoDataFrame(
+        {
+            "Loc_Code": ["M001", "M002", "M003", "M004", "M005"],
+            "Bldg_Code": ["X001", "X001", "X002", "X002", "X003"],
+            "lat": [40.700, 40.701, 40.800, 40.801, 40.900],
+            "lng": [-74.000, -74.001, -74.100, -74.101, -74.200],
+            "geometry": [
+                Point(-74.000, 40.700),
+                Point(-74.001, 40.701),
+                Point(-74.100, 40.800),
+                Point(-74.101, 40.801),
+                Point(-74.200, 40.900),
+            ],
+        },
+        crs="EPSG:4326",
+    )
+
+
+class TestSnapPointsInvariant:
+    def test_row_count_unchanged(self, schools):
+        assert len(snap_schools_by_building_code(schools)) == len(schools)
+
+    def test_crs_unchanged(self, schools):
+        assert snap_schools_by_building_code(schools).crs == schools.crs
+
+    def test_all_schools_in_same_building_share_geometry(self, schools):
+        snapped = snap_schools_by_building_code(schools)
+        multi = snapped[snapped.duplicated("Bldg_Code", keep=False)]
+        non_uniform = multi.groupby("Bldg_Code")["geometry"].apply(
+            lambda g: g.nunique() > 1
+        )
+        assert not non_uniform.any(), (
+            f"Buildings with non-identical geometries after snap: "
+            f"{non_uniform[non_uniform].index.tolist()}"
+        )
+
+    def test_lat_lng_updated_to_match_geometry(self, schools):
+        snapped = snap_schools_by_building_code(schools)
+        assert (snapped["lat"] - snapped.geometry.y).abs().max() < 1e-8
+        assert (snapped["lng"] - snapped.geometry.x).abs().max() < 1e-8

--- a/uv.lock
+++ b/uv.lock
@@ -2690,43 +2690,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pdfplumber"
-version = "0.11.8"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "pdfminer-six", version = "20251107", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pillow", marker = "python_full_version < '3.10'" },
-    { name = "pypdfium2", marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/09/d8/cb9fda4261ce389656bec0bb0bdde905df109ad97f7ae387747ded070e8c/pdfplumber-0.11.8.tar.gz", hash = "sha256:db29b04bc8bb62f39dd444533bcf2e0ba33584bd24f5a54644f3ba30f4f22d31", size = 102724, upload-time = "2025-11-08T20:52:01.955Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/28/3958ed81a9be317610ab73df32f1968076751d651c84dff1bcb45b7c6c0e/pdfplumber-0.11.8-py3-none-any.whl", hash = "sha256:7dda117b8ed21bca9c8e7d7808fee2439f93c8bd6ea45989bfb1aead6dc3cad3", size = 60043, upload-time = "2025-11-08T20:52:00.652Z" },
-]
-
-[[package]]
-name = "pdfplumber"
-version = "0.11.9"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
-dependencies = [
-    { name = "pdfminer-six", version = "20251230", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pillow", marker = "python_full_version >= '3.10'" },
-    { name = "pypdfium2", marker = "python_full_version >= '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/38/37/9ca3519e92a8434eb93be570b131476cc0a4e840bb39c62ddb7813a39d53/pdfplumber-0.11.9.tar.gz", hash = "sha256:481224b678b2bbdbf376e2c39bf914144eef7c3d301b4a28eebf0f7f6109d6dc", size = 102768, upload-time = "2026-01-05T08:10:29.072Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/c8/cdbc975f5b634e249cfa6597e37c50f3078412474f21c015e508bfbfe3c3/pdfplumber-0.11.9-py3-none-any.whl", hash = "sha256:33ec5580959ba524e9100138746e090879504c42955df1b8a997604dd326c443", size = 60045, upload-time = "2026-01-05T08:10:27.512Z" },
-]
-
-[[package]]
 name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4469,8 +4432,6 @@ dependencies = [
     { name = "matplotlib", version = "3.10.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "openpyxl" },
     { name = "pandas" },
-    { name = "pdfplumber", version = "0.11.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pdfplumber", version = "0.11.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "plotly" },
     { name = "pydeck" },
     { name = "pyproj", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -4497,7 +4458,6 @@ requires-dist = [
     { name = "matplotlib", specifier = ">=3.8.0" },
     { name = "openpyxl", specifier = ">=3.1.0" },
     { name = "pandas", specifier = ">=2.1.4" },
-    { name = "pdfplumber", specifier = ">=0.11.0" },
     { name = "plotly", specifier = ">=5.18.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.5.0" },
     { name = "pydeck", specifier = ">=0.8.0" },


### PR DESCRIPTION
## Summary
- Lift-and-shift `join_to_schools.ipynb` into `pipelines/join_to_schools.py`, modularize it, and implement the snap-points-by-building-code geometry fix (U2)
- Add a `check_join()` DQ helper and retrofit it onto all existing joins (U6)
- Add `docs/plan.md` (north star + status) and the detailed pipeline-parity unit plan
- Add unfinished lead paint hazard notebook (2025 cohorts)

## Test plan
- [ ] `just test` passes (`tests/test_snap_points.py`, `tests/test_pipeline_dq.py`)
- [ ] `pipelines/join_to_schools.py` runs end-to-end without DQ assertion failures on current data

🤖 Generated with [Claude Code](https://claude.com/claude-code)